### PR TITLE
Fix web test failures for dart2wasm and dart2js

### DIFF
--- a/lib/src/api/common/timestamp.dart
+++ b/lib/src/api/common/timestamp.dart
@@ -1,6 +1,7 @@
 // Licensed under the Apache License, Version 2.0
 // Copyright 2025, Michael Bushe, All rights reserved.
 
+import 'package:fixnum/fixnum.dart';
 import 'package:meta/meta.dart';
 
 import '../../util/time.dart';
@@ -9,15 +10,15 @@ import '../../util/time.dart';
 @immutable
 class Timestamp {
   /// Returns the current timestamp in nanoseconds since epoch.
-  static int now() => nowAsNanos().toInt();
+  static Int64 now() => nowAsNanos();
 
   /// Converts a [DateTime] to nanoseconds since epoch.
-  static int fromDateTime(DateTime dateTime) =>
-      dateTime.microsecondsSinceEpoch * 1000;
+  static Int64 fromDateTime(DateTime dateTime) =>
+      Int64(dateTime.microsecondsSinceEpoch) * 1000;
 
   /// Converts nanoseconds since epoch to a [DateTime].
-  static DateTime toDateTime(int nanos) =>
-      DateTime.fromMicrosecondsSinceEpoch(nanos ~/ 1000);
+  static DateTime toDateTime(Int64 nanos) =>
+      DateTime.fromMicrosecondsSinceEpoch((nanos ~/ 1000).toInt());
 
   /// Converts a DateTime value to a string in the format:
   /// "yyyy-MM-ddTHH:mm:ss.SSSZ"

--- a/lib/src/api/context/context.dart
+++ b/lib/src/api/context/context.dart
@@ -13,7 +13,8 @@ import '../trace/span.dart';
 import '../trace/span_context.dart';
 import 'context_key.dart';
 // Use conditional imports to handle platform differences
-import 'isolate_support.dart' if (dart.library.js) 'isolate_support_web.dart';
+import 'isolate_support.dart'
+    if (dart.library.js_interop) 'isolate_support_web.dart';
 
 part 'context_create.dart';
 

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -12,7 +12,7 @@ class IsBetween extends Matcher {
   @override
   bool matches(item, Map<dynamic, dynamic> matchState) {
     final timestamp = item as DateTime;
-    return timestamp.isAfter(before) && timestamp.isBefore(after);
+    return timestamp.compareTo(before) >= 0 && timestamp.compareTo(after) <= 0;
   }
 
   @override

--- a/test/unit/api/common/timestamp_test.dart
+++ b/test/unit/api/common/timestamp_test.dart
@@ -1,15 +1,16 @@
 // Licensed under the Apache License, Version 2.0
 // Copyright 2025, Michael Bushe, All rights reserved.
 
-import 'package:test/test.dart';
 import 'package:dartastic_opentelemetry_api/src/api/common/timestamp.dart';
+import 'package:fixnum/fixnum.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Timestamp', () {
     test('now returns nanoseconds since epoch', () {
-      final before = DateTime.now().microsecondsSinceEpoch * 1000;
+      final before = Int64(DateTime.now().microsecondsSinceEpoch) * 1000;
       final timestamp = Timestamp.now();
-      final after = DateTime.now().microsecondsSinceEpoch * 1000;
+      final after = Int64(DateTime.now().microsecondsSinceEpoch) * 1000;
 
       expect(timestamp, greaterThanOrEqualTo(before));
       expect(timestamp, lessThanOrEqualTo(after));
@@ -19,11 +20,11 @@ void main() {
       final dateTime = DateTime.fromMicrosecondsSinceEpoch(1000000);
       final nanos = Timestamp.fromDateTime(dateTime);
 
-      expect(nanos, equals(1000000 * 1000));
+      expect(nanos, equals(Int64(1000000) * 1000));
     });
 
     test('toDateTime converts nanoseconds to DateTime', () {
-      final nanos = 1000000000; // 1 second in nanos
+      final nanos = Int64(1000000000); // 1 second in nanos
       final dateTime = Timestamp.toDateTime(nanos);
 
       expect(dateTime.microsecondsSinceEpoch, equals(1000000));

--- a/test/unit/api/trace/span_test.dart
+++ b/test/unit/api/trace/span_test.dart
@@ -146,7 +146,10 @@ void main() {
 
       expect(span.isRecording, isFalse);
       expect(span.endTime, isNotNull);
-      expect(span.endTime!.isAfter(startTime), isTrue);
+      expect(
+          span.endTime!.isAfter(startTime) ||
+              span.endTime!.isAtSameMomentAs(startTime),
+          isTrue);
     });
 
     test('records specific end time when provided', () {


### PR DESCRIPTION
- Update conditional imports to use dart.library.js_interop for wasm.
- Use Int64 for nanosecond timestamps to prevent precision loss on JS.
- Make time-based matchers and tests inclusive to handle low-resolution timers.
