### PR TITLE
ci: fixed retry attempt

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -80,4 +80,4 @@ jobs:
       - name: Install dependencies
         run: dart pub get
       - name: Run web tests (dart2js + dart2wasm)
-        run: dart test -p chrome -c dart2js,dart2wasm --retry=2
+        run: dart test -p chrome -c dart2js,dart2wasm


### PR DESCRIPTION
retry needs to be in yaml for web platform, will follow up.  The correct failure will show now in ci and will be fixed by #6.