### PR TITLE
fix: trace continuity across Context.runIsolate()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.1] - 2026-05-07
+
+### Fixed
+- `Context.runIsolate()` now marks the deserialized `SpanContext` as `isRemote = true` on the receiving side. Previously the parent isolate's local SpanContext (with `isRemote = false`) was restored verbatim, so `tracer.startSpan` in the new isolate fell into the "no parent" branch and produced a fresh root span instead of a child of the parent. This now matches the W3C trace-context-from-HTTP semantic — a SpanContext that crossed a process or isolate boundary is treated as remote and parented correctly.
+
 ## [1.0.0-beta] - 2026-05-07
 
 ### Added

--- a/lib/src/api/context/context.dart
+++ b/lib/src/api/context/context.dart
@@ -335,8 +335,28 @@ class Context {
       OTelFactory.otelFactory =
           OTelFactory.deserialize(serializedFactory, factoryFactory);
 
-      // Deserialize the parent's context in the new isolate.
-      final isolateContext = deserialize(serializedContext);
+      // Deserialize the parent's context in the new isolate. Per the OTel
+      // spec ([trace/api.md §SpanContext]: "Each propagators' deserialization
+      // must set IsRemote to true on a parent SpanContext"), upgrade the
+      // propagated SpanContext to isRemote=true on the receiving side — same
+      // semantic as a SpanContext extracted from W3C trace-context HTTP
+      // headers. Crossing an isolate boundary is the same kind of process
+      // boundary.
+      final deserialized = deserialize(serializedContext);
+      final propagatedSpanContext = deserialized.spanContext;
+      final isolateContext =
+          (propagatedSpanContext != null && !propagatedSpanContext.isRemote)
+              ? deserialized.copyWithSpanContext(
+                  OTelFactory.otelFactory!.spanContext(
+                    traceId: propagatedSpanContext.traceId,
+                    spanId: propagatedSpanContext.spanId,
+                    parentSpanId: propagatedSpanContext.parentSpanId,
+                    traceFlags: propagatedSpanContext.traceFlags,
+                    traceState: propagatedSpanContext.traceState,
+                    isRemote: true,
+                  ),
+                )
+              : deserialized;
       _currentContext = isolateContext;
       _rootContext ??= isolateContext;
 
@@ -423,7 +443,9 @@ class Context {
       }
     }
 
-    // Handle span context if present and not null
+    // Handle span context if present and not null. Round-trip-faithful:
+    // isRemote is preserved as serialized. The remote-on-receiving-side
+    // override for cross-isolate transfer happens in [runIsolate].
     if (values.containsKey('spanContext')) {
       final spanContextValue = values['spanContext'];
       if (spanContextValue is Map<String, dynamic>) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartastic_opentelemetry_api
 description: Dartastic.io's OpenTelemetry API for Dart following the OpenTelemetry specification. Supports all platforms including web.
-version: 1.0.0-beta
+version: 1.0.0-beta.1
 repository: https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api.git
 homepage: https://dartastic.io
 

--- a/test/unit/api/context/isolate_transfer_test.dart
+++ b/test/unit/api/context/isolate_transfer_test.dart
@@ -44,6 +44,41 @@ void main() {
       expect(result['spanId'], equals(spanContext.spanId.toString()));
     });
 
+    test('SpanContext is marked isRemote=true after crossing isolate boundary',
+        () async {
+      // A SpanContext created in the parent isolate is by definition local
+      // (isRemote=false). When it crosses an isolate boundary via runIsolate,
+      // the receiving isolate should treat it as remote — otherwise
+      // tracer.startSpan in the new isolate falls into its "no parent"
+      // branch and creates a fresh root span instead of a child of the
+      // parent's span. This is the same semantic as W3C trace context
+      // extracted from HTTP headers.
+      final localSpanContext = OTelAPI.spanContext(
+        traceId: OTelAPI.traceId(),
+        spanId: OTelAPI.spanId(),
+        // Explicitly local in the parent isolate.
+      );
+      expect(localSpanContext.isRemote, isFalse,
+          reason: 'sanity: local SpanContext should not be remote');
+
+      final context = Context.root.withSpanContext(localSpanContext);
+
+      final result = await context.runIsolate(() async {
+        final received = Context.current.spanContext;
+        return {
+          'traceId': received?.traceId.toString(),
+          'spanId': received?.spanId.toString(),
+          'isRemote': received?.isRemote,
+        };
+      });
+
+      expect(result['traceId'], equals(localSpanContext.traceId.toString()));
+      expect(result['spanId'], equals(localSpanContext.spanId.toString()));
+      expect(result['isRemote'], isTrue,
+          reason:
+              'SpanContext crossing an isolate boundary must be marked isRemote=true so tracer.startSpan in the receiving isolate parents to it.');
+    });
+
     test('transfers custom keys only if marked as transferable', () async {
       final transferableKey =
           OTelAPI.contextKey<String>('transferable', isTransferable: true);


### PR DESCRIPTION
Summary

A SpanContext that crosses an isolate boundary via Context.runIsolate() should be isRemote=true on the receiving side, matching the OpenTelemetry specification: "Each propagators' deserialization must set IsRemote to true on a parent SpanContext" (trace/api.md
  §SpanContext (https://opentelemetry.io/docs/specs/otel/trace/api/#spancontext)). Previously the parent isolate's local SpanContext (with isRemote=false) was restored verbatim, so any code that uses the OTel-spec convention of treating remote SpanContexts as parents (e.g. APITracer.createSpan's remote-context branch) skipped the propagated SpanContext and produced a fresh root span.

Fix
In Context.runIsolate, after deserialize(serializedContext), if the resulting SpanContext has isRemote=false, rebuild it with isRemote=true before attaching to the Zone and statics. Context.deserialize itself is left round-trip-faithful — only the cross-isolate path overrides remoteness, since that's the only path where remoteness is unambiguous.                               

Added (initially failing) test for Context Isolate Transfer › SpanContext is marked isRemote=true after crossing isolate boundary.