### PR TITLE
Feat/missing semconv enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.2] - 2026-05-08
+
+### Added
+- `DatabaseResource.dbCollectionName` (`db.collection.name`) — current OTel semconv key, replaces the deprecated `db.sql.table`.
+- `DatabaseResource.dbResponseReturnedRows` (`db.response.returned_rows`) — current OTel semconv key for the row count returned by a database operation.
+- `UserSemantics.userRoles` (`user.roles`) — current OTel semconv key, an array of roles assigned to a user. Replaces the deprecated singular `user.role` (which remains for backwards compatibility).
+
 ## [1.0.0-beta.1] - 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DatabaseResource.dbResponseReturnedRows` (`db.response.returned_rows`) — current OTel semconv key for the row count returned by a database operation.
 - `UserSemantics.userRoles` (`user.roles`) — current OTel semconv key, an array of roles assigned to a user. Replaces the deprecated singular `user.role` (which remains for backwards compatibility).
 
+### Changed
+- README and example renamed the placeholder `AppAttribute` enum to `ExampleAttribute` (so readers can't blindly copy the name) and dropped the redundant `app.` prefix from invented demo keys. Where current OTel semconv keys exist, the example now uses the API's typed enums (e.g. `DatabaseResource.dbCollectionName`, `UserSemantics.userRoles`) instead of an app-defined fallback.
+
 ## [1.0.0-beta.1] - 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `DatabaseResource.dbCollectionName` (`db.collection.name`) — current OTel semconv key, replaces the deprecated `db.sql.table`.
 - `DatabaseResource.dbResponseReturnedRows` (`db.response.returned_rows`) — current OTel semconv key for the row count returned by a database operation.
-- `UserSemantics.userRoles` (`user.roles`) — current OTel semconv key, an array of roles assigned to a user. Replaces the deprecated singular `user.role` (which remains for backwards compatibility).
+- `UserSemantics.userRoles` (`user.roles`) — current OTel semconv key, an array of roles assigned to a user.
 
 ### Changed
 - README and example renamed the placeholder `AppAttribute` enum to `ExampleAttribute` (so readers can't blindly copy the name) and dropped the redundant `app.` prefix from invented demo keys. Where current OTel semconv keys exist, the example now uses the API's typed enums (e.g. `DatabaseResource.dbCollectionName`, `UserSemantics.userRoles`) instead of an app-defined fallback.
+
+### Removed
+- **Breaking:** `UserSemantics.userRole` (singular `user.role`). The singular form is an anti-pattern — users typically have multiple roles. Use `UserSemantics.userRoles` (`user.roles`) and pass a `List<String>` instead.
 
 ## [1.0.0-beta.1] - 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,32 @@ i.e. `OTelAPI.attributeString('foo', 'bar')`, `OTelAPI.attributeIntList('baz', [
 ### Basic Tracing Example
 This is a no-op when using `OTelAPI`. Use `OTel` from the SDK to record real traces.
 
+Prefer typed enum keys over raw strings for attributes. The API ships enums for every
+namespace in the [OTel semantic conventions](https://opentelemetry.io/docs/specs/semconv/)
+(`HttpResource`, `UrlResource`, `ServerResource`, `DatabaseResource`, `UserSemantics`, etc.)
+For app-specific attributes that aren't in a convention, define your own enum implementing
+`OTelSemantic`.
+
 ```dart
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+
+/// Example-only attribute keys for things not in the OTel semantic
+/// conventions. Rename this in your own code (e.g. `CheckoutAttribute`)
+/// so the names reflect your domain.
+enum ExampleAttribute implements OTelSemantic {
+  operationSuccess('operation.success'),
+  operationValue('operation.value'),
+  retryCount('retry.count'),
+  requestDuration('request.duration'),
+  requestSuccess('request.success'),
+  tags('tags');
+
+  @override
+  final String key;
+  @override
+  String toString() => key;
+  const ExampleAttribute(this.key);
+}
 
 void main() {
   // Get a tracer.
@@ -151,30 +175,36 @@ void main() {
   // so that any spans started inside are parented to it via the active
   // context. Use withSpanAsync for asynchronous scopes.
   final rootSpan = tracer.startSpan('main-operation');
-  tracer.withSpan(rootSpan, () {
-    try {
-      rootSpan.setBoolAttribute('operation.success', true);
+  try {
+    tracer.withSpan(rootSpan, () {
+      rootSpan.setBoolAttribute(ExampleAttribute.operationSuccess.key, true);
 
-      // Child span — parented to rootSpan via the active context.
-      // Wrap each span in try/finally so it's always ended, even on error.
+      // Child span — parented to rootSpan via the active context. Wrap
+      // each span in its own try/catch/finally so exceptions are recorded
+      // on the right span and the span is always ended.
       final childSpan = tracer.startSpan('sub-operation');
       try {
         tracer.withSpan(childSpan, () {
-          childSpan.setIntAttribute('operation.value', 42);
+          childSpan.setIntAttribute(ExampleAttribute.operationValue.key, 42);
         });
+        childSpan.setStatus(SpanStatusCode.Ok);
+      } catch (e, stackTrace) {
+        // Per the OTel spec: recordException first, then setStatus(Error).
+        childSpan.recordException(e, stackTrace: stackTrace);
+        childSpan.setStatus(SpanStatusCode.Error, e.toString());
+        rethrow;
       } finally {
         childSpan.end();
       }
-    } catch (e, stackTrace) {
-      rootSpan
-        ..setStatus(SpanStatusCode.Error, e.toString())
-        ..recordException(e, stackTrace: stackTrace);
-      rethrow;
-    } finally {
-      // end() defaults the status to Ok if it was never set.
-      rootSpan.end();
-    }
-  });
+    });
+    rootSpan.setStatus(SpanStatusCode.Ok);
+  } catch (e, stackTrace) {
+    rootSpan.recordException(e, stackTrace: stackTrace);
+    rootSpan.setStatus(SpanStatusCode.Error, e.toString());
+    rethrow;
+  } finally {
+    rootSpan.end();
+  }
 }
 ```
 
@@ -218,24 +248,27 @@ void main() {
     'example_int_list_key': [42, 43, 44],
   });
 
-  // Using the typesafe API methods
+  // Using the typesafe API methods. Mix API convention enums (e.g.
+  // ServiceResource) with your own enum (ExampleAttribute) for
+  // non-convention keys — never use raw strings.
   Attributes attributes = OTelAPI.attributes([
-    OTelAPI.attributeString('service.name', 'payment-processor'),
-    OTelAPI.attributeInt('retry.count', 3),
-    OTelAPI.attributeDouble('request.duration', 0.125),
-    OTelAPI.attributeBool('request.success', true),
-    OTelAPI.attributeStringList('tags', ['payment', 'critical']),
+    OTelAPI.attributeString(
+        ServiceResource.serviceName.key, 'payment-processor'),
+    OTelAPI.attributeInt(ExampleAttribute.retryCount.key, 3),
+    OTelAPI.attributeDouble(ExampleAttribute.requestDuration.key, 0.125),
+    OTelAPI.attributeBool(ExampleAttribute.requestSuccess.key, true),
+    OTelAPI.attributeStringList(
+        ExampleAttribute.tags.key, ['payment', 'critical']),
   ]);
-  
-  // Using Map extension
+
+  // Using Map extension — same enum-key principle.
   Attributes fromMap = <String, Object>{
-    'http.method': 'GET',
-    'http.url': 'https://api.example.com/users',
-    'http.status_code': 200,
-    'environment': 'production',
-    'user.roles': ['admin', 'operator'],
+    HttpResource.requestMethod.key: 'GET',
+    UrlResource.urlFull.key: 'https://api.example.com/users',
+    HttpResource.responseStatusCode.key: 200,
+    DeploymentResource.deploymentEnvironmentName.key: 'production',
+    UserSemantics.userRoles.key: ['admin', 'operator'],
   }.toAttributes();
-  
 }
 ```
 
@@ -247,9 +280,9 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 final otelLoggerProvider = OTelAPI.loggerProvider();
 final otelLogger = otelLoggerProvider.getLogger('dart-otel-api-faux-db-service');
 final attrs = {
-  'db.operation': 'update',
-  'db.table': 'orders',
-  'db.rows_affected': 3,
+  DatabaseResource.dbOperation.key: 'update',
+  DatabaseResource.dbCollectionName.key: 'orders',
+  DatabaseResource.dbResponseReturnedRows.key: 3,
 }.toAttributes();
 
 otelLogger.emit(

--- a/example/dartastic_opentelemetry_api_example.dart
+++ b/example/dartastic_opentelemetry_api_example.dart
@@ -3,23 +3,64 @@
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 
+/// Example-only attribute keys used in this file. Prefer enums over raw
+/// strings — the API's built-in semantic-convention enums (UserSemantics,
+/// HttpResource, DatabaseResource, etc.) cover the OTel-defined keys; this
+/// enum holds the keys that aren't in any convention. In your own app,
+/// rename this to something domain-specific (e.g. `CheckoutAttribute`).
+enum ExampleAttribute implements OTelSemantic {
+  // Generic demo keys showing attribute types.
+  exampleString('example.string'),
+  exampleBool('example.bool'),
+  exampleInt('example.int'),
+  exampleDouble('example.double'),
+  exampleStringList('example.string_list'),
+  exampleBoolList('example.bool_list'),
+  exampleIntList('example.int_list'),
+  exampleDoubleList('example.double_list'),
+  eventFoo('event.foo'),
+  // Auth / cache / batch / payment / retry — none of these are in the
+  // OTel semantic conventions, so they're app-defined here.
+  authMethod('auth.method'),
+  cacheKey('cache.key'),
+  cacheRegion('cache.region'),
+  batchId('batch.id'),
+  jobsTotal('jobs.total'),
+  paymentUserId('payment.user_id'),
+  paymentMethod('payment.method'),
+  paymentGateway('payment.gateway'),
+  retryCount('retry.count');
+
+  @override
+  final String key;
+
+  @override
+  String toString() => key;
+
+  const ExampleAttribute(this.key);
+}
+
 /// The API does nothing on its own; it's more typical to use the SDK.
 /// However, as required by the OpenTelemetry Specification, the API
 /// works (as a no-op) without the SDK installed.
 void main() {
   OTelAPI.initialize(endpoint: 'http://localhost:4317');
-  final stringAttribute = OTelAPI.attributeString('example_string_key', 'foo');
-  final boolAttribute = OTelAPI.attributeBool('example_bool_key', true);
-  final intAttr = OTelAPI.attributeInt('example_int_key', 42);
-  final doubleAttribute = OTelAPI.attributeDouble('example_double_key', 42.1);
+  // Use typed enum keys — never raw strings.
+  final stringAttribute =
+      OTelAPI.attributeString(ExampleAttribute.exampleString.key, 'foo');
+  final boolAttribute =
+      OTelAPI.attributeBool(ExampleAttribute.exampleBool.key, true);
+  final intAttr = OTelAPI.attributeInt(ExampleAttribute.exampleInt.key, 42);
+  final doubleAttribute =
+      OTelAPI.attributeDouble(ExampleAttribute.exampleDouble.key, 42.1);
   final stringListAttribute = OTelAPI.attributeStringList(
-      'example_string_list_key', ['foo', 'bar', 'baz']);
-  final boolListAttribute =
-      OTelAPI.attributeBoolList('example_bool_key', [true, false, true]);
-  final intListAttr =
-      OTelAPI.attributeIntList('example_int_list_key', [42, 43, 44]);
+      ExampleAttribute.exampleStringList.key, ['foo', 'bar', 'baz']);
+  final boolListAttribute = OTelAPI.attributeBoolList(
+      ExampleAttribute.exampleBoolList.key, [true, false, true]);
+  final intListAttr = OTelAPI.attributeIntList(
+      ExampleAttribute.exampleIntList.key, [42, 43, 44]);
   final doubleListAttribute = OTelAPI.attributeDoubleList(
-      'example_double_list_key', [42.0, 42.1, 42.2]);
+      ExampleAttribute.exampleDoubleList.key, [42.0, 42.1, 42.2]);
 
   OTelAPI.attributes([
     stringAttribute,
@@ -41,28 +82,41 @@ void main() {
     final tracer = defaultGlobalAPINOOPTracerProvider
         .getTracer('dart-otel-api-example-service');
 
-    // Use withSpan to make the span active within its scope
+    // Use withSpan to make the span active within its scope. Wrap the work
+    // in try/catch/finally so the span is always ended and any thrown
+    // exception is recorded with SpanStatusCode.Error per the OTel spec.
     final span = tracer.startSpan('doSomeExampleSpan');
-    tracer.withSpan(span, () {
-      // Same thing as above, more simply but will some loss of type checking
-      // If your Map has anything but the types above and exception will be thrown.
-      final equalToTheAbove = OTelAPI.attributesFromMap({
-        'example_string_key': 'foo',
-        'example_bool_key': true,
-        'example_int_key': 42,
-        'example_double_key': 42.1,
-        'example_string_list_key': ['foo', 'bar', 'baz'],
-        'example_bool_list_key': [true, false, true],
-        'example_int_list_key': [42, 43, 44],
-        'example_double_list_key': [42.0, 42.1, 42.2]
+    try {
+      tracer.withSpan(span, () {
+        // Same thing as above, more simply but with some loss of type
+        // checking. If your Map has anything but the types above an
+        // exception will be thrown.
+        final equalToTheAbove = OTelAPI.attributesFromMap({
+          ExampleAttribute.exampleString.key: 'foo',
+          ExampleAttribute.exampleBool.key: true,
+          ExampleAttribute.exampleInt.key: 42,
+          ExampleAttribute.exampleDouble.key: 42.1,
+          ExampleAttribute.exampleStringList.key: ['foo', 'bar', 'baz'],
+          ExampleAttribute.exampleBoolList.key: [true, false, true],
+          ExampleAttribute.exampleIntList.key: [42, 43, 44],
+          ExampleAttribute.exampleDoubleList.key: [42.0, 42.1, 42.2],
+        });
+        span.attributes = equalToTheAbove;
+        span.addEventNow(
+          'data-retrieved',
+          OTelAPI.attributes(
+              [OTelAPI.attributeString(ExampleAttribute.eventFoo.key, 'bar')]),
+        );
       });
-      span.attributes = equalToTheAbove;
-      span.addEventNow('data-retrieved',
-          OTelAPI.attributes([OTelAPI.attributeString('event-foo', 'bar')]));
-      span.end(
-          spanStatus:
-              SpanStatusCode.Ok); //Capitalized Ok to match the OTel spec
-    });
+      // Capitalized Ok to match the OTel spec.
+      span.setStatus(SpanStatusCode.Ok);
+    } catch (e, stackTrace) {
+      span.recordException(e, stackTrace: stackTrace);
+      span.setStatus(SpanStatusCode.Error, e.toString());
+      rethrow;
+    } finally {
+      span.end();
+    }
 
     //Log Signal
     final defaultGlobalAPINOOPLoggerProvider = OTelAPI.loggerProvider();
@@ -76,8 +130,8 @@ void main() {
       severityNumber: Severity.INFO,
       body: 'User successfully logged in.',
       attributes: Attributes.of({
-        'user.id': 42,
-        'auth.method': 'password',
+        UserSemantics.userId.key: 42,
+        ExampleAttribute.authMethod.key: 'password',
       }),
     );
 
@@ -86,15 +140,15 @@ void main() {
       severityText: 'WARN',
       body: 'Cache miss for requested key.',
       attributes: Attributes.of({
-        'cache.key': 'profile_42',
-        'cache.region': 'us-east-1',
+        ExampleAttribute.cacheKey.key: 'profile_42',
+        ExampleAttribute.cacheRegion.key: 'us-east-1',
       }),
     );
 
     final attrs = {
-      'db.operation': 'update',
-      'db.table': 'orders',
-      'db.rows_affected': 3,
+      DatabaseResource.dbOperation.key: 'update',
+      DatabaseResource.dbCollectionName.key: 'orders',
+      DatabaseResource.dbResponseReturnedRows.key: 3,
     }.toAttributes();
 
     logger.emit(
@@ -107,14 +161,17 @@ void main() {
     logger.emit(
       eventName: 'batch_job_summary',
       severityNumber: Severity.INFO,
+      // Body is a user-defined structure (per the OTel logs spec) — its
+      // inner keys are not span/log attributes, so they don't go through
+      // an OTelSemantic enum.
       body: [
         {'job': 'resize_images', 'status': 'ok'},
         {'job': 'generate_thumbnails', 'status': 'ok'},
         {'job': 'sync_metadata', 'status': 'failed'},
       ],
       attributes: Attributes.of({
-        'batch.id': 'batch-2025-11-15-01',
-        'jobs.total': 3,
+        ExampleAttribute.batchId.key: 'batch-2025-11-15-01',
+        ExampleAttribute.jobsTotal.key: 3,
       }),
     );
 
@@ -123,10 +180,10 @@ void main() {
       severityText: 'ERROR',
       body: 'Payment could not be processed.',
       attributes: Attributes.of({
-        'payment.user_id': 101,
-        'payment.method': 'credit_card',
-        'payment.gateway': 'stripe',
-        'retry.count': 2,
+        ExampleAttribute.paymentUserId.key: 101,
+        ExampleAttribute.paymentMethod.key: 'credit_card',
+        ExampleAttribute.paymentGateway.key: 'stripe',
+        ExampleAttribute.retryCount.key: 2,
       }),
     );
   });

--- a/lib/src/api/semantics/resource_semantics.dart
+++ b/lib/src/api/semantics/resource_semantics.dart
@@ -93,7 +93,11 @@ enum DatabaseResource implements OTelSemantic {
   dbUser('db.user'),
   dbName('db.name'),
   dbStatement('db.statement'),
-  dbOperation('db.operation');
+  dbOperation('db.operation'),
+  // Current OTel semconv (replaces deprecated `db.sql.table`).
+  dbCollectionName('db.collection.name'),
+  // Current OTel semconv for "rows returned by the operation".
+  dbResponseReturnedRows('db.response.returned_rows');
 
   @override
   final String key;

--- a/lib/src/api/semantics/ui_semantics.dart
+++ b/lib/src/api/semantics/ui_semantics.dart
@@ -299,9 +299,9 @@ enum SessionViewSemantics implements OTelSemantic {
 /// RUM Semantics related to user information
 enum UserSemantics implements OTelSemantic {
   userId('user.id'),
-  userRole('user.role'),
-  // Current OTel semconv: array of roles a user is assigned. Replaces
-  // the deprecated singular `user.role`.
+  // Array of roles a user is assigned. The singular `user.role` is an
+  // anti-pattern — users typically have multiple roles, so always model
+  // this as a list.
   userRoles('user.roles'),
   userSession('user.session');
 

--- a/lib/src/api/semantics/ui_semantics.dart
+++ b/lib/src/api/semantics/ui_semantics.dart
@@ -300,6 +300,9 @@ enum SessionViewSemantics implements OTelSemantic {
 enum UserSemantics implements OTelSemantic {
   userId('user.id'),
   userRole('user.role'),
+  // Current OTel semconv: array of roles a user is assigned. Replaces
+  // the deprecated singular `user.role`.
+  userRoles('user.roles'),
   userSession('user.session');
 
   @override

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -86,14 +86,12 @@ class APISpan {
       if (spanContext.parentSpanId != parentSpan.spanContext.spanId) {
         throw ArgumentError('Parent span ID must match');
       }
-    } else {
-      // Root spans should have an invalid (all zeros) parent span ID
-      if (spanContext.parentSpanId != null &&
-          spanContext.parentSpanId!.bytes == SpanId.invalidSpanIdBytes) {
-        throw ArgumentError(
-            'Root spans must have invalid (all zeros) parent span ID or no parent span ID');
-      }
     }
+    // No `else` branch: when parentSpan is null, the span may legitimately
+    // have any parentSpanId (null, the invalid all-zeros marker, OR a
+    // valid remote span id propagated from an upstream context). The
+    // remote-parent case is a normal W3C trace-context flow and must
+    // not be rejected here.
   }
 
   /// The name of this [APISpan].

--- a/lib/src/api/trace/span_create.dart
+++ b/lib/src/api/trace/span_create.dart
@@ -48,14 +48,12 @@ class APISpanCreate {
       if (spanContext.parentSpanId != parentSpan.spanContext.spanId) {
         throw ArgumentError('Child span must reference parent span ID');
       }
-    } else {
-      // Root spans should have an invalid (all zeros) parent span ID
-      if (spanContext.parentSpanId != null &&
-          spanContext.parentSpanId!.bytes == SpanId.invalidSpanIdBytes) {
-        throw ArgumentError(
-            'Root spans must have invalid (all zeros) parent span ID or no parent span ID');
-      }
     }
+    // No `else` branch: when parentSpan is null, the span may legitimately
+    // have any parentSpanId (null, the invalid all-zeros marker, OR a
+    // valid remote span id propagated from an upstream context). The
+    // remote-parent case is a normal W3C trace-context flow and must
+    // not be rejected here.
     return APISpan._(
         name: name,
         spanContext: spanContext,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartastic_opentelemetry_api
 description: Dartastic.io's OpenTelemetry API for Dart following the OpenTelemetry specification. Supports all platforms including web.
-version: 1.0.0-beta.1
+version: 1.0.0-beta.2
 repository: https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api.git
 homepage: https://dartastic.io
 

--- a/test/unit/api/semantics/ui_semantics_test.dart
+++ b/test/unit/api/semantics/ui_semantics_test.dart
@@ -21,11 +21,49 @@ void main() {
           equals('device.app.lifecycle.paused'));
     });
 
+    test('AppLifecycleStates.appLifecycleStateFor maps platform strings', () {
+      expect(AppLifecycleStates.appLifecycleStateFor('detached'),
+          equals(AppLifecycleStates.detached));
+      expect(AppLifecycleStates.appLifecycleStateFor('resumed'),
+          equals(AppLifecycleStates.resumed));
+      expect(AppLifecycleStates.appLifecycleStateFor('inactive'),
+          equals(AppLifecycleStates.inactive));
+      expect(AppLifecycleStates.appLifecycleStateFor('hidden'),
+          equals(AppLifecycleStates.hidden));
+      expect(AppLifecycleStates.appLifecycleStateFor('paused'),
+          equals(AppLifecycleStates.paused));
+      // Unknown / unspecified strings fall back to active.
+      expect(AppLifecycleStates.appLifecycleStateFor('active'),
+          equals(AppLifecycleStates.active));
+      expect(AppLifecycleStates.appLifecycleStateFor('garbage'),
+          equals(AppLifecycleStates.active));
+      expect(AppLifecycleStates.appLifecycleStateFor(''),
+          equals(AppLifecycleStates.active));
+    });
+
     test('AppLifecycleSemantics toString returns key', () {
       expect(AppLifecycleSemantics.appLaunchId.toString(),
           equals('app.launch.id'));
+      expect(AppLifecycleSemantics.appLifecycleId.toString(),
+          equals('app_lifecycle.id'));
+      expect(AppLifecycleSemantics.appLifecycleChange.toString(),
+          equals('app_lifecycle.changed'));
       expect(AppLifecycleSemantics.appLifecycleState.toString(),
           equals('app_lifecycle.state'));
+      expect(AppLifecycleSemantics.appLifecycleStateId.toString(),
+          equals('app_lifecycle.state_id'));
+      expect(AppLifecycleSemantics.appLifecyclePreviousState.toString(),
+          equals('app_lifecycle.previous_state'));
+      expect(AppLifecycleSemantics.appLifecyclePreviousStateId.toString(),
+          equals('app_lifecycle.previous_state_id'));
+      expect(AppLifecycleSemantics.appLifecyclePreviousLifecycleId.toString(),
+          equals('app_lifecycle.previous_lifecycle_id'));
+      expect(AppLifecycleSemantics.appLifecycleTimestamp.toString(),
+          equals('app_lifecycle.timestamp'));
+      expect(AppLifecycleSemantics.appLifecycleDuration.toString(),
+          equals('app_lifecycle.duration'));
+      expect(AppLifecycleSemantics.appStartType.toString(),
+          equals('app.start.type'));
     });
 
     test('AppStartType toString returns key', () {
@@ -36,16 +74,41 @@ void main() {
     test('AppInfoSemantics toString returns key', () {
       expect(AppInfoSemantics.appId.toString(), equals('app.id'));
       expect(AppInfoSemantics.appName.toString(), equals('app.name'));
+      expect(AppInfoSemantics.appVersion.toString(), equals('app.version'));
+      expect(AppInfoSemantics.appBuildNumber.toString(),
+          equals('app.build_number'));
+      expect(AppInfoSemantics.appPackageName.toString(),
+          equals('app.package_name'));
     });
 
     test('DeviceSemantics toString returns key', () {
       expect(DeviceSemantics.deviceId.toString(), equals('device.id'));
       expect(DeviceSemantics.deviceModel.toString(), equals('device.model'));
+      expect(
+          DeviceSemantics.devicePlatform.toString(), equals('device.platform'));
+      expect(DeviceSemantics.deviceOsVersion.toString(),
+          equals('device.os_version'));
+      expect(DeviceSemantics.isPhysicalDevice.toString(),
+          equals('device.physical'));
+      expect(DeviceSemantics.isiOSAppOnMac.toString(),
+          equals('device.ios_on_mac'));
     });
 
     test('BatterySemantics toString returns key', () {
       expect(BatterySemantics.batteryLevel.toString(), equals('battery.level'));
       expect(BatterySemantics.batteryState.toString(), equals('battery.state'));
+      expect(BatterySemantics.batteryStateFull.toString(),
+          equals('battery.state.full'));
+      expect(BatterySemantics.batteryStateCharging.toString(),
+          equals('battery.state.charging'));
+      expect(BatterySemantics.batteryStateConnectedNotCharging.toString(),
+          equals('battery.state.connected_not_charging'));
+      expect(BatterySemantics.batteryStateDischanrging.toString(),
+          equals('battery.state.discharging'));
+      expect(BatterySemantics.batteryStateUnknown.toString(),
+          equals('battery.state.unknown'));
+      expect(BatterySemantics.batterySaveMode.toString(),
+          equals('battery.save_mode'));
     });
 
     test('NavigationSemantics toString returns key', () {
@@ -53,11 +116,57 @@ void main() {
           equals('navigation.action'));
       expect(NavigationSemantics.navigationTrigger.toString(),
           equals('navigation.trigger'));
+      expect(NavigationSemantics.navigationTimestamp.toString(),
+          equals('navigation.timestamp'));
+      expect(NavigationSemantics.routeName.toString(),
+          equals('navigation.route.name'));
+      expect(NavigationSemantics.routeId.toString(),
+          equals('navigation.route.id'));
+      expect(NavigationSemantics.routeKey.toString(),
+          equals('navigation.route.key'));
+      expect(NavigationSemantics.routePath.toString(),
+          equals('navigation.route.path'));
+      expect(NavigationSemantics.routeArguments.toString(),
+          equals('navigation.route.arguments'));
+      expect(NavigationSemantics.routeTimestamp.toString(),
+          equals('navigation.route.timestamp'));
+      expect(NavigationSemantics.previousRouteName.toString(),
+          equals('navigation.previous_route_name'));
+      expect(NavigationSemantics.previousRouteId.toString(),
+          equals('navigation.previous_route_id'));
+      expect(NavigationSemantics.previousRoutePath.toString(),
+          equals('navigation.previous_route_path'));
+      expect(NavigationSemantics.previousRouteDuration.toString(),
+          equals('route.previous_route_duration'));
+      expect(NavigationSemantics.routeTransitionDuration.toString(),
+          equals('route.transition_duration'));
     });
 
     test('InteractionType toString returns key', () {
       expect(InteractionType.click.toString(), equals('click'));
+      expect(InteractionType.drag.toString(), equals('drag'));
+      expect(InteractionType.focusChange.toString(), equals('focus_change'));
+      expect(InteractionType.formSubmit.toString(), equals('form_submit'));
+      expect(InteractionType.keydown.toString(), equals('keydown'));
+      expect(InteractionType.keyup.toString(), equals('keyup'));
+      expect(
+          InteractionType.listSelection.toString(), equals('list_selection'));
+      expect(InteractionType.listSelectionIndex.toString(),
+          equals('list_selected_index'));
+      expect(InteractionType.longPress.toString(), equals('long_press'));
+      expect(InteractionType.menuSelect.toString(), equals('menu_select'));
+      expect(InteractionType.menuSelectedItem.toString(),
+          equals('menu_selected_item'));
+      expect(InteractionType.scroll.toString(), equals('scroll'));
+      expect(InteractionType.swipe.toString(), equals('swipe'));
       expect(InteractionType.tap.toString(), equals('tap'));
+      expect(InteractionType.textInput.toString(), equals('text_input'));
+      expect(
+          InteractionType.gestureDeltaX.toString(), equals('gesture.delta_x'));
+      expect(
+          InteractionType.gestureDeltaY.toString(), equals('gesture.delta_y'));
+      expect(InteractionType.gestureDirection.toString(),
+          equals('gesture.direction'));
     });
 
     test('InteractionSemantics toString returns key', () {
@@ -65,34 +174,76 @@ void main() {
           equals('user_interaction'));
       expect(InteractionSemantics.interactionType.toString(),
           equals('interaction.type'));
+      expect(InteractionSemantics.interactionTarget.toString(),
+          equals('interaction.target'));
+      expect(InteractionSemantics.interactionResult.toString(),
+          equals('interaction.result'));
+      expect(InteractionSemantics.inputDelay.toString(), equals('input.delay'));
     });
 
     test('PerformanceSemantics toString returns key', () {
       expect(PerformanceSemantics.renderDuration.toString(),
           equals('render.duration'));
       expect(PerformanceSemantics.firstPaint.toString(), equals('first.paint'));
+      expect(PerformanceSemantics.firstContentfulPaint.toString(),
+          equals('first.contentful.paint'));
+      expect(PerformanceSemantics.timeToInteractive.toString(),
+          equals('time.to.interactive'));
+      expect(PerformanceSemantics.frameTime.toString(), equals('frame.time'));
+      expect(PerformanceSemantics.frameRate.toString(), equals('frame.rate'));
+      expect(PerformanceSemantics.jankCount.toString(), equals('jank.count'));
+      expect(
+          PerformanceSemantics.memoryUsage.toString(), equals('memory.usage'));
+      expect(PerformanceSemantics.rumFirstInputDelay.toString(),
+          equals('first_input_delay'));
     });
 
     test('ErrorSemantics toString returns key', () {
       expect(ErrorSemantics.errorType.toString(), equals('error.type'));
+      expect(ErrorSemantics.errorSource.toString(), equals('error.source'));
       expect(ErrorSemantics.errorMessage.toString(), equals('error.message'));
+      expect(ErrorSemantics.errorStacktrace.toString(),
+          equals('error.stacktrace'));
+      expect(ErrorSemantics.crashFreeSessionRate.toString(),
+          equals('crash.free.session.rate'));
     });
 
     test('NetworkSemantics toString returns key', () {
       expect(NetworkSemantics.networkConnectivity.toString(),
           equals('network.connectivity'));
       expect(NetworkSemantics.networkType.toString(), equals('network.type'));
+      expect(NetworkSemantics.networkRequestUrl.toString(),
+          equals('network.request.url'));
+      expect(NetworkSemantics.networkRequestDuration.toString(),
+          equals('network.request.duration'));
     });
 
     test('SessionViewSemantics toString returns key', () {
       expect(SessionViewSemantics.sessionId.toString(), equals('session.id'));
       expect(
           SessionViewSemantics.rumSessionId.toString(), equals('session_id'));
+      expect(SessionViewSemantics.sessionStart.toString(),
+          equals('session.start'));
+      expect(SessionViewSemantics.sessionDuration.toString(),
+          equals('session.duration'));
+      expect(SessionViewSemantics.viewName.toString(), equals('view.name'));
+      expect(SessionViewSemantics.rumViewName.toString(), equals('view_name'));
+      expect(SessionViewSemantics.rumViewId.toString(), equals('view_id'));
+      expect(SessionViewSemantics.viewStart.toString(), equals('view.start'));
+      expect(SessionViewSemantics.viewDuration.toString(),
+          equals('view.duration'));
+      expect(SessionViewSemantics.rumViewLoadTime.toString(),
+          equals('view_load_time'));
+      expect(SessionViewSemantics.rumActionCount.toString(),
+          equals('action.count'));
+      expect(SessionViewSemantics.rumUserSatisfactionScore.toString(),
+          equals('user_satisfaction_score'));
     });
 
     test('UserSemantics toString returns key', () {
       expect(UserSemantics.userId.toString(), equals('user.id'));
       expect(UserSemantics.userRoles.toString(), equals('user.roles'));
+      expect(UserSemantics.userSession.toString(), equals('user.session'));
     });
   });
 }

--- a/test/unit/api/semantics/ui_semantics_test.dart
+++ b/test/unit/api/semantics/ui_semantics_test.dart
@@ -92,7 +92,7 @@ void main() {
 
     test('UserSemantics toString returns key', () {
       expect(UserSemantics.userId.toString(), equals('user.id'));
-      expect(UserSemantics.userRole.toString(), equals('user.role'));
+      expect(UserSemantics.userRoles.toString(), equals('user.roles'));
     });
   });
 }

--- a/test/unit/api/trace/span_root_validation_test.dart
+++ b/test/unit/api/trace/span_root_validation_test.dart
@@ -1,31 +1,38 @@
 // Licensed under the Apache License, Version 2.0
 // Copyright 2025, Michael Bushe, All rights reserved.
 
-// Coverage tests for APISpan / APISpanCreate root-vs-child validation
+// Coverage tests for APISpan / APISpanCreate root-span construction
 // and SpanContextCreate default fallbacks.
 //
-// These tests exercise contracts that were previously uncovered:
+// What "no parentSpan" actually means in OTel:
 //
-//   APISpanCreate.create + APISpan._ root-span validation:
-//     - parentSpan == null AND parentSpanId is null → no throw
-//     - parentSpan == null AND parentSpanId is the invalid (all-zeros)
-//       SpanId → no throw (the documented "valid root" form)
-//     - parentSpan == null AND parentSpanId is a valid non-zero SpanId
-//       → MUST throw ArgumentError (a root span cannot reference an
-//       arbitrary parent span ID without a parentSpan).
+//   parentSpan == null does NOT imply "true root span." It only means
+//   there is no in-process parent Span object to reference. The W3C
+//   trace-context propagation flow produces spans where parentSpan is
+//   null but parentSpanId is set to a valid remote span id (carried in
+//   from a `traceparent` header or equivalent). That is a legitimate
+//   OTel pattern, not a malformed root.
+//
+//   Therefore APISpan / APISpanCreate must not reject any specific
+//   parentSpanId shape when parentSpan is null. Earlier code in this
+//   file *attempted* such a validation but the condition was inverted
+//   AND used Uint8List `==` (identity equality on a fresh-copy getter)
+//   so it never fired anyway. The dead code has been removed; this
+//   suite locks down the legitimate construction shapes so the cleanup
+//   doesn't regress.
 //
 //   SpanContextCreate.create defaults:
 //     - traceId/spanId omitted → SpanContextCreate falls back to factory
-//       generators (these `??` branches are unreachable from
+//       generators. These `??` branches are unreachable from
 //       OTelAPI.spanContext() because that wrapper substitutes defaults
 //       *before* calling the factory; the factory-direct path still
-//       needs the fallbacks).
+//       needs the fallbacks.
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Root span parentSpanId validation', () {
+  group('Root / parent-less span construction', () {
     late APITracer tracer;
 
     setUp(() {
@@ -38,10 +45,10 @@ void main() {
       tracer = OTelAPI.tracer('test-tracer');
     });
 
-    test('tracer.startSpan creates a root span without throwing', () {
-      // Sanity: the standard root-span creation path through the tracer
-      // sets parentSpanId to the invalid (all-zeros) SpanId, which is
-      // the OTel-spec form of "this is a root."
+    test('tracer.startSpan creates a true root span', () {
+      // The standard root-span path through the tracer sets parentSpanId
+      // to the invalid (all-zeros) SpanId, which is the OTel-spec form
+      // of "this is a root."
       final span = tracer.startSpan('root');
       expect(span.parentSpan, isNull);
       expect(span.spanContext.parentSpanId, isNotNull);
@@ -74,12 +81,12 @@ void main() {
     });
 
     test(
-        'createSpan with invalid (all-zeros) parentSpanId and no parentSpan does not throw',
+        'createSpan with explicit invalid (all-zeros) parentSpanId and no parentSpan does not throw',
         () {
-      // The OTel spec lets a root span carry the invalid SpanId as its
-      // parentSpanId — that is the canonical "no parent" marker.
-      // OTelAPI.spanContext() normalises invalid → null at the API
-      // boundary, so build the SpanContext via the factory directly.
+      // Build the SpanContext via the factory directly — OTelAPI.spanContext
+      // normalises an invalid parentSpanId to null at the API boundary,
+      // so the only way to materialise the all-zeros form on the SpanContext
+      // is to skip the wrapper.
       final ctx = OTelFactory.otelFactory!.spanContext(
         traceId: OTelAPI.traceId(),
         spanId: OTelAPI.spanId(),
@@ -99,31 +106,34 @@ void main() {
     });
 
     test(
-        'createSpan with valid non-zero parentSpanId and no parentSpan throws ArgumentError',
+        'createSpan with valid non-zero parentSpanId and no parentSpan succeeds (remote-parent flow)',
         () {
-      // A root span (parentSpan == null) must not carry a non-zero
-      // parentSpanId — there is no parent to reference. The error
-      // message explicitly states: "Root spans must have invalid
-      // (all zeros) parent span ID or no parent span ID".
-      final orphanedParent = OTelAPI.spanId(); // valid, non-zero
-      expect(orphanedParent.isValid, isTrue);
+      // This is the W3C trace-context propagation pattern: an incoming
+      // request carries a `traceparent` header, the receiver builds a
+      // remote SpanContext from it, and starts a new span whose
+      // parentSpanId is the upstream span's id. The new span has no
+      // in-process parentSpan but is NOT a root.
+      final remoteParentSpanId = OTelAPI.spanId();
+      expect(remoteParentSpanId.isValid, isTrue);
 
       final ctx = OTelAPI.spanContext(
         traceId: OTelAPI.traceId(),
         spanId: OTelAPI.spanId(),
-        parentSpanId: orphanedParent,
+        parentSpanId: remoteParentSpanId,
       );
-
       // Sanity: the API didn't normalise our valid parentSpanId away.
-      expect(ctx.parentSpanId, equals(orphanedParent));
+      expect(ctx.parentSpanId, equals(remoteParentSpanId));
 
+      // Must succeed — span_create.dart / span.dart cannot distinguish
+      // the remote-parent case from a malformed root, and the OTel spec
+      // permits the remote-parent shape, so no throw.
       expect(
         () => tracer.createSpan(
-          name: 'orphan-with-fake-parent',
+          name: 'remote-parent',
           spanContext: ctx,
           parentSpan: null,
         ),
-        throwsA(isA<ArgumentError>()),
+        returnsNormally,
       );
     });
   });

--- a/test/unit/api/trace/span_root_validation_test.dart
+++ b/test/unit/api/trace/span_root_validation_test.dart
@@ -1,0 +1,156 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Coverage tests for APISpan / APISpanCreate root-vs-child validation
+// and SpanContextCreate default fallbacks.
+//
+// These tests exercise contracts that were previously uncovered:
+//
+//   APISpanCreate.create + APISpan._ root-span validation:
+//     - parentSpan == null AND parentSpanId is null → no throw
+//     - parentSpan == null AND parentSpanId is the invalid (all-zeros)
+//       SpanId → no throw (the documented "valid root" form)
+//     - parentSpan == null AND parentSpanId is a valid non-zero SpanId
+//       → MUST throw ArgumentError (a root span cannot reference an
+//       arbitrary parent span ID without a parentSpan).
+//
+//   SpanContextCreate.create defaults:
+//     - traceId/spanId omitted → SpanContextCreate falls back to factory
+//       generators (these `??` branches are unreachable from
+//       OTelAPI.spanContext() because that wrapper substitutes defaults
+//       *before* calling the factory; the factory-direct path still
+//       needs the fallbacks).
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Root span parentSpanId validation', () {
+    late APITracer tracer;
+
+    setUp(() {
+      OTelAPI.reset();
+      OTelAPI.initialize(
+        endpoint: 'http://localhost:4317',
+        serviceName: 'test-service',
+        serviceVersion: '1.0.0',
+      );
+      tracer = OTelAPI.tracer('test-tracer');
+    });
+
+    test('tracer.startSpan creates a root span without throwing', () {
+      // Sanity: the standard root-span creation path through the tracer
+      // sets parentSpanId to the invalid (all-zeros) SpanId, which is
+      // the OTel-spec form of "this is a root."
+      final span = tracer.startSpan('root');
+      expect(span.parentSpan, isNull);
+      expect(span.spanContext.parentSpanId, isNotNull);
+      expect(span.spanContext.parentSpanId!.isValid, isFalse);
+    });
+
+    test(
+        'createSpan with omitted parentSpanId and no parentSpan does not throw',
+        () {
+      // SpanContextCreate.create defaults a null parentSpanId to the
+      // invalid SpanId — the OTel-spec form for "no parent." So even
+      // when the caller omits parentSpanId, the resulting context's
+      // parentSpanId is the invalid (all-zeros) marker, not literally
+      // null.
+      final ctx = OTelAPI.spanContext(
+        traceId: OTelAPI.traceId(),
+        spanId: OTelAPI.spanId(),
+      );
+      expect(ctx.parentSpanId, isNotNull);
+      expect(ctx.parentSpanId!.isValid, isFalse);
+
+      expect(
+        () => tracer.createSpan(
+          name: 'orphan-default',
+          spanContext: ctx,
+          parentSpan: null,
+        ),
+        returnsNormally,
+      );
+    });
+
+    test(
+        'createSpan with invalid (all-zeros) parentSpanId and no parentSpan does not throw',
+        () {
+      // The OTel spec lets a root span carry the invalid SpanId as its
+      // parentSpanId — that is the canonical "no parent" marker.
+      // OTelAPI.spanContext() normalises invalid → null at the API
+      // boundary, so build the SpanContext via the factory directly.
+      final ctx = OTelFactory.otelFactory!.spanContext(
+        traceId: OTelAPI.traceId(),
+        spanId: OTelAPI.spanId(),
+        parentSpanId: OTelAPI.spanIdInvalid(),
+      );
+      expect(ctx.parentSpanId, isNotNull);
+      expect(ctx.parentSpanId!.isValid, isFalse);
+
+      expect(
+        () => tracer.createSpan(
+          name: 'orphan-invalid',
+          spanContext: ctx,
+          parentSpan: null,
+        ),
+        returnsNormally,
+      );
+    });
+
+    test(
+        'createSpan with valid non-zero parentSpanId and no parentSpan throws ArgumentError',
+        () {
+      // A root span (parentSpan == null) must not carry a non-zero
+      // parentSpanId — there is no parent to reference. The error
+      // message explicitly states: "Root spans must have invalid
+      // (all zeros) parent span ID or no parent span ID".
+      final orphanedParent = OTelAPI.spanId(); // valid, non-zero
+      expect(orphanedParent.isValid, isTrue);
+
+      final ctx = OTelAPI.spanContext(
+        traceId: OTelAPI.traceId(),
+        spanId: OTelAPI.spanId(),
+        parentSpanId: orphanedParent,
+      );
+
+      // Sanity: the API didn't normalise our valid parentSpanId away.
+      expect(ctx.parentSpanId, equals(orphanedParent));
+
+      expect(
+        () => tracer.createSpan(
+          name: 'orphan-with-fake-parent',
+          spanContext: ctx,
+          parentSpan: null,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('SpanContextCreate factory defaults', () {
+    setUp(() {
+      OTelAPI.reset();
+      OTelAPI.initialize(
+        endpoint: 'http://localhost:4317',
+        serviceName: 'test-service',
+        serviceVersion: '1.0.0',
+      );
+    });
+
+    test('OTelFactory.spanContext() generates a valid traceId when omitted',
+        () {
+      // Factory-direct path (no OTelAPI wrapper) — exercises the
+      // `traceId ?? factory.traceId()` fallback in SpanContextCreate.
+      final ctx = OTelFactory.otelFactory!.spanContext();
+      expect(ctx.traceId.isValid, isTrue);
+    });
+
+    test('OTelFactory.spanContext() generates a valid spanId when omitted', () {
+      // Factory-direct path — exercises the `spanId ?? factory.spanId()`
+      // fallback in SpanContextCreate.
+      final ctx = OTelFactory.otelFactory!.spanContext();
+      expect(ctx.spanId.isValid, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Targets `1.0.0-beta.2`.                                                                                                            
                                                        
  ### API additions (current OTel semconv)                                                                                           
  - `DatabaseResource.dbCollectionName` (`db.collection.name`) — replaces deprecated `db.sql.table`                                  
  - `DatabaseResource.dbResponseReturnedRows` (`db.response.returned_rows`)
  - `UserSemantics.userRoles` (`user.roles`)                                                                                         
                                                                                            
  ### Breaking removal                                                                                                               
  - `UserSemantics.userRole` (singular `user.role`) — anti-pattern; users typically have multiple roles. Migrate to `userRoles` and
  pass a `List<String>`.                                                                                                             
                                                                                                                                     
  ### Internal cleanup (no observable behavior change)                                                                               
  - Removed dead root-span `parentSpanId` validation in `APISpanCreate.create` and `APISpan._`. Two stacked bugs (an inverted        
  condition + Uint8List `==` identity equality on a fresh-copy `bytes` getter) made the throw unreachable in all branches. Removing
  it is a no-op against today's behavior — and the contract the comment claimed is in fact too strict for the W3C remote-parent flow 
  (incoming `traceparent` → span with `parentSpan == null` + valid non-zero `parentSpanId`), so re-implementing it correctly here
  would have broken legitimate traces.                                                                                               
  - Landed via the failing-test-first TDD pair (commits `846c928` test → `387b226` fix). Investigation surfaced the contract         
  mismatch; both files cleaned up together.            
                                                                                                                                     
  ### Example + README overhaul                                                             
  - All raw-string attribute keys replaced with typed enum keys. Where no semconv key exists, demo keys live in a typed              
  `ExampleAttribute` enum implementing `OTelSemantic`.                                      
  - Placeholder enum named `ExampleAttribute` (not `AppAttribute`) so readers rename it for their domain instead of copy-pasting     
  verbatim. The redundant `app.` prefix was dropped from invented demo keys.                
  - Span lifecycle in the example now follows the OTel spec exactly: `try/catch/finally`, `recordException(e, stackTrace:
  stackTrace)` *before* `setStatus(Error)`, `span.end()` in `finally`. README's basic-tracing snippet rewritten the same way (and to 
  use `withSpan` for the spec-aligned active-span scope).
  - Example exercises a wider range of log shapes (`heartbeat`, `user_login`, `cache_miss`, `order_update`, `batch_job_summary`,     
  `payment_failure`).                                                                       
  - README baggage example reads via `Context.current.baggage` and runs the body inside `runSync`, matching the new Zone-based       
  propagation contract from beta.1.                                                         
                                                                                                                                     
  ### Test coverage                                                                         
  - New `span_root_validation_test.dart` locks down the actual root / parent-less / remote-parent construction contracts plus        
  `SpanContextCreate` factory defaults (the fallbacks unreachable from `OTelAPI.spanContext()`).
  - `ui_semantics_test.dart` now asserts every enum entry's `.toString()` and exercises `AppLifecycleStates.appLifecycleStateFor`    
  including the unknown-string fallback.           