### PR TITLE
Fix/service namespace mangle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.3] - unreleased
+
+### Fixed
+- **Breaking:** `ServiceResource.serviceResourcepace` (key `service.Resourcepace`) was a mangled find/replace artifact (`Name` → `Resource` accidentally hit `serviceNamespace`). Restored the correct OTel semconv entry: `ServiceResource.serviceNamespace` with key `service.namespace`. Migration: replace `ServiceResource.serviceResourcepace` with `ServiceResource.serviceNamespace`.
+
 ## [1.0.0-beta.2] - 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0-beta.3] - unreleased
+## [1.0.0-beta.3-wip]
 
 ### Fixed
 - **Breaking:** `ServiceResource.serviceResourcepace` (key `service.Resourcepace`) was a mangled find/replace artifact (`Name` → `Resource` accidentally hit `serviceNamespace`). Restored the correct OTel semconv entry: `ServiceResource.serviceNamespace` with key `service.namespace`. Migration: replace `ServiceResource.serviceResourcepace` with `ServiceResource.serviceNamespace`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ There are many ways to contribute to this project:
 ## Pull Request Process
 
 1. Update the README.md or other documentation with details of changes if appropriate
-2. Update the CHANGELOG.md with a description of your changes
+2. Add a CHANGELOG entry for your change under the `## [X.Y.Z-wip]` section at the top of `CHANGELOG.md`. The version stamp ends in `-wip` during development; `tool/release.sh` strips it and dates the section at release time. **Do not edit `pubspec.yaml`'s version line in your PR** — release tooling owns it.
 3. The PR should work with the latest version of Dart and be compatible with all supported platforms
 4. The PR will be merged once it receives approval from project maintainers
 
@@ -145,17 +145,31 @@ Feature requests are welcome. Please provide:
 
 ## Release Process
 
-The release process is handled by project maintainers. If you're a maintainer, follow these steps:
+The release process is handled by project maintainers via
+`tool/release.sh`, which implements the Flutter / Dart team's `-wip`
+convention. The working `pubspec.yaml` version always ends in `-wip`
+and CHANGELOG entries during development land under
+`## [X.Y.Z-wip]`. To cut a release:
 
-1. Update version in `pubspec.yaml`
-2. Update CHANGELOG.md with all changes since the last release
-3. Create a release commit
-4. Tag the release commit with the version number (e.g., `v1.0.0`)
-5. Push the commit and tag to the repository
-6. Publish to pub.dev:
-   ```bash
-   dart pub publish
-   ```
+```bash
+tool/release.sh                       # auto-bump trailing number
+tool/release.sh --next 1.2.0-beta     # override the next dev version
+tool/release.sh --yes                 # non-interactive (CI)
+```
+
+The script strips `-wip` from `pubspec.yaml` and the CHANGELOG header,
+dates the section, runs `dart pub get` / `analyze` / `test`, commits
+as `Release X.Y.Z`, tags `vX.Y.Z`, then bumps `pubspec.yaml` to the
+next `-wip` version with a fresh `## [X.Y.Z-wip]` CHANGELOG section
+and commits as `Bump to X.Y.Z-wip`. After it succeeds, push and
+publish manually:
+
+```bash
+git push origin HEAD vX.Y.Z
+dart pub publish
+```
+
+See `PUBLICATION_CHECKLIST.md` for the full pre-release checklist.
 
 ## Communication
 

--- a/PUBLICATION_CHECKLIST.md
+++ b/PUBLICATION_CHECKLIST.md
@@ -13,8 +13,8 @@ This document outlines the steps to follow when publishing a new version of the 
 
 ### Documentation
 - [ ] Documentation is up-to-date with the current version
-- [ ] CHANGELOG.md is updated with all notable changes
-- [ ] Version numbers are updated in relevant files
+- [ ] CHANGELOG.md entries for this release land under the `## [X.Y.Z-wip]` section
+- [ ] `pubspec.yaml` version still ends in `-wip` (the release script strips it)
 - [ ] Examples reflect current API usage
 
 ### Compatibility
@@ -28,31 +28,49 @@ This document outlines the steps to follow when publishing a new version of the 
 
 ## Release Process
 
-1. **Prepare Release**
-   - [ ] Update version in `pubspec.yaml`
-   - [ ] Update CHANGELOG.md with release date and changes
-   - [ ] Create a git tag for the version (e.g., `git tag v1.0.0`)
-   - [ ] Push the tag to the repository (`git push origin v1.0.0`)
+This repo follows the Flutter / Dart team's `-wip` convention. The
+working `pubspec.yaml` version always ends in `-wip` and CHANGELOG
+entries land under a `## [X.Y.Z-wip]` section header during
+development. `tool/release.sh` performs the release.
 
-2. **Publish to pub.dev**
-   - [ ] Run final `dart pub publish --dry-run` check
-   - [ ] Publish with `dart pub publish`
+1. **Prepare Release**
+   - [ ] Working tree is clean and on `main` (or the release branch).
+   - [ ] CHANGELOG `## [X.Y.Z-wip]` section reflects everything in this release.
+   - [ ] `dart pub publish --dry-run` is clean.
+
+2. **Cut the release** — run `tool/release.sh`. The script:
+   - Strips `-wip` from `pubspec.yaml` and the CHANGELOG header, dates
+     the section.
+   - Runs `dart pub get`, `dart analyze`, `dart test`.
+   - Commits as `Release X.Y.Z` and tags `vX.Y.Z`.
+   - Bumps `pubspec.yaml` to next `-wip` (auto-bumps the rightmost
+     numeric component, or pass `--next X.Y.Z` to override).
+   - Inserts a fresh `## [X.Y.Z-wip]` CHANGELOG section.
+   - Commits as `Bump to X.Y.Z-wip`.
+   - Pass `--yes` for non-interactive runs.
+
+3. **Push and publish**
+   - [ ] `git push origin HEAD vX.Y.Z`
+   - [ ] `dart pub publish`
    - [ ] Verify package appears correctly on pub.dev
 
-3. **Post-Release**
-   - [ ] Create a GitHub release with release notes
+4. **Post-Release**
+   - [ ] Create a GitHub release with release notes (use the
+         CHANGELOG entry as the body)
    - [ ] Announce in appropriate channels (if applicable)
    - [ ] Update documentation website (if applicable)
-   - [ ] Increment to next development version
 
 ## Emergency Fixes
 
 If an emergency fix is required for a released version:
 
-1. Create a hotfix branch from the tagged release
-2. Make minimal required changes
-3. Follow the standard release process but increment the PATCH version
-4. Merge the fix back to the main branch if applicable
+1. Create a hotfix branch from the tagged release.
+2. Set `pubspec.yaml` version to the patch-bump form ending in `-wip`
+   (e.g. for a `v1.0.0` hotfix, use `1.0.1-wip`).
+3. Add the fix and a `## [1.0.1-wip]` CHANGELOG section.
+4. Run `tool/release.sh` to cut `1.0.1`.
+5. Cherry-pick the fix back to `main` if applicable. If main was on a
+   newer wip already, just keep that wip number — don't downgrade.
 
 ## CNCF Contribution Considerations
 

--- a/lib/src/api/semantics/resource_semantics.dart
+++ b/lib/src/api/semantics/resource_semantics.dart
@@ -529,7 +529,7 @@ enum UrlResource implements OTelSemantic {
 /// [Specification](https://opentelemetry.io/docs/specs/semconv/resource/#service)
 enum ServiceResource implements OTelSemantic {
   serviceName('service.name'),
-  serviceResourcepace('service.Resourcepace'),
+  serviceNamespace('service.namespace'),
   serviceInstanceId('service.instance.id'),
   serviceVersion('service.version');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartastic_opentelemetry_api
 description: Dartastic.io's OpenTelemetry API for Dart following the OpenTelemetry specification. Supports all platforms including web.
-version: 1.0.0-beta.2
+version: 1.0.0-beta.3-wip
 repository: https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api.git
 homepage: https://dartastic.io
 

--- a/test/unit/api/semantics/resource_semantics_test.dart
+++ b/test/unit/api/semantics/resource_semantics_test.dart
@@ -519,11 +519,26 @@ void main() {
         expect(value.toString(), equals(value.key));
       }
       expect(ServiceResource.serviceName.key, equals('service.name'));
-      expect(ServiceResource.serviceResourcepace.key,
-          equals('service.Resourcepace'));
       expect(
           ServiceResource.serviceInstanceId.key, equals('service.instance.id'));
       expect(ServiceResource.serviceVersion.key, equals('service.version'));
+    });
+
+    test('ServiceResource exposes service.namespace per OTel semconv', () {
+      // A find/replace of "Name" → "Resource" once mangled the
+      // `serviceNamespace('service.namespace')` entry into
+      // `serviceResourcepace('service.Resourcepace')`. This test asserts
+      // the spec-correct key is present, looking up via the enum's
+      // values list so it compiles against any name the entry happens
+      // to have.
+      final allKeys = ServiceResource.values.map((e) => e.key).toList();
+      expect(
+        allKeys,
+        contains('service.namespace'),
+        reason:
+            'ServiceResource must expose the OTel-spec key `service.namespace`. '
+            'Found keys: $allKeys',
+      );
     });
 
     test('SourceCodeResource toString and key', () {

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# tool/release.sh — Flutter/Dart team -wip release pattern.
+#
+# Reads the version from pubspec.yaml, which MUST end in `-wip`. Then:
+#   1. Strips `-wip` from pubspec.yaml.
+#   2. Replaces the `## [X.Y.Z-wip]` CHANGELOG header with
+#      `## [X.Y.Z] - YYYY-MM-DD`.
+#   3. Runs `dart pub get`, `dart analyze`, and `dart test`.
+#   4. Commits as `Release X.Y.Z` and tags `vX.Y.Z`.
+#   5. Bumps pubspec to next `-wip` version (rightmost numeric component
+#      + 1 by default, or `--next` to override).
+#   6. Inserts a fresh `## [next-wip]` section above the just-released
+#      one in CHANGELOG.md.
+#   7. Commits as `Bump to <next-wip>`.
+#
+# After success, push and publish manually:
+#     git push origin HEAD vX.Y.Z
+#     dart pub publish
+#
+# Usage:
+#     tool/release.sh                       # auto-bump trailing number
+#     tool/release.sh --next 1.2.0-beta     # override the next version
+#     tool/release.sh --yes                 # skip confirmation prompt
+#
+# Aborts if the working tree isn't clean. If anything fails after
+# pubspec/CHANGELOG have been edited but before the commit, recover
+# with:
+#     git checkout pubspec.yaml CHANGELOG.md
+#     git tag -d vX.Y.Z   # only if the tag was created
+
+set -euo pipefail
+
+NEXT_OVERRIDE=""
+ASSUME_YES=0
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --next) NEXT_OVERRIDE="$2"; shift 2;;
+    --yes|-y) ASSUME_YES=1; shift;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0;;
+    *) echo "unknown arg: $1" >&2; exit 1;;
+  esac
+done
+
+# require clean working tree
+if ! git diff-index --quiet HEAD --; then
+  echo "error: working tree is dirty. commit or stash first." >&2
+  exit 1
+fi
+
+# read current version
+CURRENT=$(grep -E '^version:' pubspec.yaml | head -1 | awk '{print $2}')
+if [[ -z $CURRENT ]]; then
+  echo "error: could not read version from pubspec.yaml" >&2
+  exit 1
+fi
+
+if [[ $CURRENT != *-wip ]]; then
+  echo "error: pubspec.yaml version is '$CURRENT' — expected to end in -wip." >&2
+  echo "       did you already release? bump to the next -wip version." >&2
+  exit 1
+fi
+
+RELEASE=${CURRENT%-wip}
+TODAY=$(date +%Y-%m-%d)
+
+# verify CHANGELOG has a section for the wip version
+if ! grep -qE "^##[[:space:]]*\\[?${CURRENT//./\\.}\\]?" CHANGELOG.md; then
+  echo "error: CHANGELOG.md has no section header for $CURRENT" >&2
+  echo "       expected '## [$CURRENT]' or '## $CURRENT'." >&2
+  exit 1
+fi
+
+# compute next-wip
+if [[ -n $NEXT_OVERRIDE ]]; then
+  NEXT_WIP="${NEXT_OVERRIDE%-wip}-wip"
+else
+  if [[ $RELEASE =~ ([0-9]+)$ ]]; then
+    NUM=${BASH_REMATCH[1]}
+    PREFIX=${RELEASE%$NUM}
+    NEXT_WIP="${PREFIX}$((NUM+1))-wip"
+  else
+    echo "error: cannot auto-bump '$RELEASE' (no trailing number)." >&2
+    echo "       use --next <version> to specify it explicitly." >&2
+    exit 1
+  fi
+fi
+
+cat <<EOM
+
+  Releasing: $RELEASE   (was: $CURRENT)
+  Next dev:  $NEXT_WIP
+
+EOM
+
+if [[ $ASSUME_YES -ne 1 ]]; then
+  printf 'Continue? [y/N] '
+  read -r reply
+  [[ $reply == y || $reply == Y ]] || { echo "aborted."; exit 1; }
+fi
+
+cleanup_msg() {
+  cat >&2 <<EOM
+
+error: failed mid-release. To recover:
+  git checkout pubspec.yaml CHANGELOG.md
+  git tag -d v$RELEASE 2>/dev/null || true
+
+EOM
+}
+trap cleanup_msg ERR
+
+# 1) strip -wip from pubspec
+perl -i -pe "s|^(version:\\s*)\\Q$CURRENT\\E\\s*\$|\${1}$RELEASE|" pubspec.yaml
+
+# 2) date the CHANGELOG section header
+perl -i -pe "s|^(##[[:space:]]*)\\[?\\Q$CURRENT\\E\\]?.*\$|\${1}[$RELEASE] - $TODAY|" CHANGELOG.md
+
+# 3) sanity check
+dart pub get >/dev/null
+dart analyze
+dart test
+
+# 4) commit + tag
+git add pubspec.yaml CHANGELOG.md
+git commit -m "Release $RELEASE"
+git tag "v$RELEASE"
+echo "✓ tagged v$RELEASE"
+
+# 5) bump pubspec to next -wip
+perl -i -pe "s|^(version:\\s*)\\Q$RELEASE\\E\\s*\$|\${1}$NEXT_WIP|" pubspec.yaml
+
+# 6) inject a fresh wip section above the just-released one
+perl -i -pe "
+  if (!\$done && /^##[[:space:]]*\\[\\Q$RELEASE\\E\\]/) {
+    print \"## [$NEXT_WIP]\n\n\";
+    \$done = 1;
+  }
+" CHANGELOG.md
+
+# 7) commit
+git add pubspec.yaml CHANGELOG.md
+git commit -m "Bump to $NEXT_WIP"
+
+trap - ERR
+
+cat <<EOM
+
+✓ done.
+
+Next steps:
+  git push origin HEAD v$RELEASE
+  dart pub publish
+
+If publish fails or you need to roll back the tag:
+  git tag -d v$RELEASE
+  git push origin :refs/tags/v$RELEASE   # only if already pushed
+  git reset --hard HEAD~2
+
+EOM


### PR DESCRIPTION
Targets `1.0.0-beta.3`. Two unrelated-but-bundled chunks: a real bug fix (TDD pair) and the release-tooling setup that adopts the
  `-wip` convention.                                                                                                                 
   
  ### Bug fix — `ServiceResource.serviceNamespace` was mangled                                                                       
  A find/replace of "Name" → "Resource" once hit `serviceNamespace`, mangling it into:
                                                                                                                                     
  ```dart
  serviceResourcepace('service.Resourcepace'),                                                                                       
                                                            
  Both the entry name and the key string were wrong. The existing per-key assertion in resource_semantics_test.dart had been edited  
  alongside the bug to match the broken values, so the regression hid behind a green test — classic "high coverage, wrong assertion."
                                                                                                                                     
  Landed as a TDD pair:                                     

  - ff384ad test: failing test for ServiceResource.serviceNamespace mangle                                                           
    - Test fix: drops the expect(ServiceResource.serviceResourcepace.key, equals('service.Resourcepace')) assertion that pinned the
  buggy values.                                                                                                                      
    - Adds a service.namespace membership check via ServiceResource.values lookup. Compiles against the buggy code (no symbol
  reference to a not-yet-existing entry) and fails because no entry has the spec key yet.
  - be977d8 fix: ServiceResource.serviceNamespace (was mangled to serviceResourcepace)
    - Renames the entry to serviceNamespace('service.namespace'). Failing test goes green.

  Marked Breaking in CHANGELOG since anyone who happened to use the buggy ServiceResource.serviceResourcepace symbol or the
  service.Resourcepace key string needs to migrate to serviceNamespace / service.namespace.

  Release tooling — tool/release.sh + -wip convention

  - 02cae7b chore: add tool/release.sh and adopt -wip release convention

  Adopts the Flutter / Dart team's pattern: working pubspec.yaml version always ends in -wip; CHANGELOG entries during development
  land under ## [X.Y.Z-wip]. tool/release.sh strips -wip, dates the section, runs dart pub get / analyze / test, commits + tags, then
   bumps to next--wip and inserts a fresh CHANGELOG section.

  tool/release.sh                       # auto-bump trailing number
  tool/release.sh --next 1.2.0-beta     # override the next dev version
  tool/release.sh --yes                 # non-interactive (CI)

  After it succeeds, push and publish manually (git push origin HEAD vX.Y.Z and dart pub publish). Aborts on a dirty tree; prints
  recovery hints if it fails mid-run.

  This commit also flips the current pending release into the new convention:
  - pubspec.yaml: 1.0.0-beta.2 → 1.0.0-beta.3-wip
  - CHANGELOG.md: ## [1.0.0-beta.3] - unreleased → ## [1.0.0-beta.3-wip]
  - PUBLICATION_CHECKLIST.md: Release Process rewritten around tool/release.sh; pre-release checklist now asserts -wip state.
  - CONTRIBUTING.md: PR Process tells contributors to add CHANGELOG entries under ## [X.Y.Z-wip] and not edit pubspec.yaml version
  (release tooling owns it). Release Process points at tool/release.sh.

