### PR TITLE
chore(release): auto-checkout tag + auto-publish in release.dart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,19 +154,26 @@ and CHANGELOG entries during development land under
 ```bash
 dart tool/release.dart                       # auto-bump trailing number
 dart tool/release.dart --next 1.2.0-beta     # override the next dev version
-dart tool/release.dart --yes                 # non-interactive (CI)
+dart tool/release.dart --no-publish          # cut release locally only
+dart tool/release.dart --skip-tests          # skip `dart test` (e.g. CI runs it separately)
+dart tool/release.dart --yes                 # non-interactive confirm
 ```
 
 The script strips `-wip` from `pubspec.yaml` and the CHANGELOG header,
 dates the section, runs `dart pub get` / `analyze` / `test`, commits
 as `Release X.Y.Z`, tags `vX.Y.Z`, then bumps `pubspec.yaml` to the
 next `-wip` version with a fresh `## [X.Y.Z-wip]` CHANGELOG section
-and commits as `Bump to X.Y.Z-wip`. After it succeeds, push and
-publish manually:
+and commits as `Bump to X.Y.Z-wip`. It then checks out the `vX.Y.Z`
+tag and runs `dart pub publish` from there — pub publish reads the
+working tree, so this guarantees the published version matches the
+tag instead of the (still-`-wip`) bump commit. pub.dev's own
+confirmation prompt is the publish gate. On success the script
+returns the working tree to your branch.
+
+After it succeeds, push:
 
 ```bash
 git push origin HEAD vX.Y.Z
-dart pub publish
 ```
 
 See `PUBLICATION_CHECKLIST.md` for the full pre-release checklist.

--- a/PUBLICATION_CHECKLIST.md
+++ b/PUBLICATION_CHECKLIST.md
@@ -38,7 +38,7 @@ development. `dart tool/release.dart` performs the release.
    - [ ] CHANGELOG `## [X.Y.Z-wip]` section reflects everything in this release.
    - [ ] `dart pub publish --dry-run` is clean.
 
-2. **Cut the release** — run `dart tool/release.dart`. The script:
+2. **Cut and publish the release** — run `dart tool/release.dart`. The script:
    - Strips `-wip` from `pubspec.yaml` and the CHANGELOG header, dates
      the section.
    - Runs `dart pub get`, `dart analyze`, `dart test`.
@@ -47,11 +47,16 @@ development. `dart tool/release.dart` performs the release.
      numeric component, or pass `--next X.Y.Z` to override).
    - Inserts a fresh `## [X.Y.Z-wip]` CHANGELOG section.
    - Commits as `Bump to X.Y.Z-wip`.
-   - Pass `--yes` for non-interactive runs.
+   - Checks out the `vX.Y.Z` tag and runs `dart pub publish` so the
+     working tree being published actually matches the release version.
+     pub.dev's own `Do you want to publish ...?` prompt is the gate.
+   - Returns the working tree to your branch on success.
+   - Flags: `--yes` for non-interactive confirm, `--no-publish` to
+     stop after the local commits, `--skip-tests` to skip `dart test`,
+     `--next X.Y.Z` to override the bumped dev version.
 
-3. **Push and publish**
+3. **Push**
    - [ ] `git push origin HEAD vX.Y.Z`
-   - [ ] `dart pub publish`
    - [ ] Verify package appears correctly on pub.dev
 
 4. **Post-Release**

--- a/tool/release.dart
+++ b/tool/release.dart
@@ -13,15 +13,20 @@
 ///      + 1 by default; `--next X.Y.Z` to override).
 ///   6. Inserts a fresh `## [next-wip]` CHANGELOG section.
 ///   7. Commits as `Bump to <next-wip>`.
+///   8. Checks out the `vX.Y.Z` tag (so the working tree shows the
+///      released version, not the wip bump) and runs `dart pub publish`.
+///      pub.dev's own confirmation prompt is the publish gate.
+///   9. Returns the working tree to the original branch.
 ///
-/// After success, push and publish manually:
-///     git push origin HEAD vX.Y.Z
-///     dart pub publish
+/// After success, push:
+///     git push origin BRANCH vX.Y.Z
 ///
 /// Usage:
-///     dart tool/release.dart                       # auto-bump
-///     dart tool/release.dart --next 1.2.0-beta     # override next
-///     dart tool/release.dart --yes                 # non-interactive
+///     dart tool/release.dart                       # auto-bump + publish
+///     dart tool/release.dart --next 1.2.0-beta     # override next dev
+///     dart tool/release.dart --no-publish          # cut release locally only
+///     dart tool/release.dart --skip-tests          # skip `dart test`
+///     dart tool/release.dart --yes                 # non-interactive confirm
 ///
 /// Design notes:
 /// - Reading is done via `package:pubspec_parse`, which produces a typed
@@ -30,12 +35,18 @@
 /// - Writing is line-precise: we never round-trip the YAML through a
 ///   parser-printer, so comments and formatting in `pubspec.yaml` are
 ///   preserved bit-for-bit. Only the single `version:` line changes.
+/// - Auto-publishing avoids a known footgun: `dart pub publish` reads
+///   the working tree, so if you ran the release script and then ran
+///   `dart pub publish` manually from HEAD, you would end up offering
+///   the `-wip` bump version to pub.dev. Step 8 checks out the release
+///   tag first so the working tree reflects the version being published.
 /// - The previous `tool/release.sh` used a perl substitution whose
 ///   `\s*$` greedily ate the trailing `\n` and joined the version line
 ///   with the next line. Doing this in Dart with a typed reader and
 ///   line-based writer makes that whole class of bug impossible.
 library;
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:pub_semver/pub_semver.dart';
@@ -45,13 +56,14 @@ const _wipSuffix = '-wip';
 const _pubspecPath = 'pubspec.yaml';
 const _changelogPath = 'CHANGELOG.md';
 
-void main(List<String> args) {
+Future<void> main(List<String> args) async {
   final flags = _Flags.parse(args);
 
   if (!_isWorkingTreeClean()) {
     _die('working tree is dirty. commit or stash first.');
   }
 
+  final originalRef = _currentRef();
   final current = _readWipVersion();
   final release = _stripWip(current);
   final nextWip = _computeNextWip(release, override: flags.nextOverride);
@@ -65,6 +77,7 @@ void main(List<String> args) {
     ..writeln()
     ..writeln('  Releasing: $release   (was: $current)')
     ..writeln('  Next dev:  $nextWip')
+    ..writeln('  Publish:   ${flags.publish ? "yes (auto)" : "no"}')
     ..writeln();
 
   if (!flags.assumeYes) {
@@ -85,7 +98,11 @@ void main(List<String> args) {
     );
     _runOrThrow('dart', ['pub', 'get'], silent: true);
     _runOrThrow('dart', ['analyze']);
-    _runOrThrow('dart', ['test']);
+    if (!flags.skipTests) {
+      _runOrThrow('dart', ['test']);
+    } else {
+      stdout.writeln('(skipping `dart test` — --skip-tests)');
+    }
     _runOrThrow('git', ['add', _pubspecPath, _changelogPath]);
     _runOrThrow('git', ['commit', '-m', 'Release $release']);
     _runOrThrow('git', ['tag', 'v$release']);
@@ -107,13 +124,46 @@ void main(List<String> args) {
     exit(1);
   }
 
+  // ---- publish ----
+  if (flags.publish) {
+    stdout
+      ..writeln()
+      ..writeln('Checking out v$release for publish '
+          '(pub publish reads the working tree, not the tag)...');
+    _runOrThrow('git', ['checkout', 'v$release']);
+    var publishOk = false;
+    try {
+      publishOk = await _runInteractive('dart', ['pub', 'publish']);
+    } finally {
+      stdout.writeln('Returning working tree to $originalRef...');
+      _runOrThrow('git', ['checkout', originalRef]);
+    }
+    if (!publishOk) {
+      stderr
+        ..writeln()
+        ..writeln('error: `dart pub publish` did not succeed.')
+        ..writeln('The local commits and the v$release tag are still in '
+            'place — you can re-publish with:')
+        ..writeln('  git checkout v$release && dart pub publish && '
+            'git checkout $originalRef')
+        ..writeln();
+      exit(1);
+    }
+  }
+
   stdout
     ..writeln()
     ..writeln('✓ done.')
     ..writeln()
     ..writeln('Next steps:')
-    ..writeln('  git push origin HEAD v$release')
-    ..writeln('  dart pub publish')
+    ..writeln('  git push origin $originalRef v$release');
+  if (!flags.publish) {
+    stdout
+      ..writeln('  git checkout v$release')
+      ..writeln('  dart pub publish')
+      ..writeln('  git checkout $originalRef');
+  }
+  stdout
     ..writeln()
     ..writeln('To roll back the local commits and tag (before push):')
     ..writeln('  git tag -d v$release')
@@ -126,14 +176,23 @@ void main(List<String> args) {
 // ---------------------------------------------------------------------------
 
 class _Flags {
-  _Flags({this.nextOverride, required this.assumeYes});
+  _Flags({
+    this.nextOverride,
+    required this.assumeYes,
+    required this.publish,
+    required this.skipTests,
+  });
 
   final String? nextOverride;
   final bool assumeYes;
+  final bool publish;
+  final bool skipTests;
 
   static _Flags parse(List<String> args) {
     String? nextOverride;
     var assumeYes = false;
+    var publish = true;
+    var skipTests = false;
     for (var i = 0; i < args.length; i++) {
       final a = args[i];
       switch (a) {
@@ -143,6 +202,10 @@ class _Flags {
         case '--yes':
         case '-y':
           assumeYes = true;
+        case '--no-publish':
+          publish = false;
+        case '--skip-tests':
+          skipTests = true;
         case '-h':
         case '--help':
           _printUsage();
@@ -151,12 +214,18 @@ class _Flags {
           _die('unknown arg: $a');
       }
     }
-    return _Flags(nextOverride: nextOverride, assumeYes: assumeYes);
+    return _Flags(
+      nextOverride: nextOverride,
+      assumeYes: assumeYes,
+      publish: publish,
+      skipTests: skipTests,
+    );
   }
 }
 
 void _printUsage() {
-  stdout.writeln('Usage: dart tool/release.dart [--next <version>] [--yes]');
+  stdout.writeln('Usage: dart tool/release.dart '
+      '[--next <version>] [--yes] [--no-publish] [--skip-tests]');
   stdout.writeln();
   stdout.writeln('See the file header for full docs.');
 }
@@ -315,6 +384,26 @@ bool _isWorkingTreeClean() {
   return (r.stdout as String).trim().isEmpty;
 }
 
+/// Returns the current symbolic ref (branch name) or, if HEAD is
+/// detached, the abbreviated commit SHA. Used as the "return to"
+/// target after the publish step.
+String _currentRef() {
+  final symbolic = Process.runSync('git', ['symbolic-ref', '--quiet', 'HEAD']);
+  if (symbolic.exitCode == 0) {
+    final ref = (symbolic.stdout as String).trim();
+    if (ref.startsWith('refs/heads/')) {
+      return ref.substring('refs/heads/'.length);
+    }
+    return ref;
+  }
+  // Detached HEAD — fall back to the commit SHA.
+  final sha = Process.runSync('git', ['rev-parse', 'HEAD']);
+  if (sha.exitCode != 0) {
+    _die('cannot resolve HEAD');
+  }
+  return (sha.stdout as String).trim();
+}
+
 String _today() {
   final n = DateTime.now();
   String pad(int v, [int w = 2]) => v.toString().padLeft(w, '0');
@@ -333,6 +422,21 @@ void _runOrThrow(String exe, List<String> args, {bool silent = false}) {
       '$exe ${args.join(' ')} failed (exit ${r.exitCode})',
     );
   }
+}
+
+/// Runs [exe] [args] with stdio inherited from this process so the
+/// child's prompts (e.g. `dart pub publish`'s y/N confirmation) and
+/// streaming output reach the user's terminal directly. Returns true
+/// on exit code 0.
+Future<bool> _runInteractive(String exe, List<String> args) async {
+  stdout.writeln('\$ $exe ${args.join(' ')}');
+  final p = await Process.start(
+    exe,
+    args,
+    mode: ProcessStartMode.inheritStdio,
+  );
+  final code = await p.exitCode;
+  return code == 0;
 }
 
 Never _die(String msg) {


### PR DESCRIPTION
Closes a footgun in the previous release flow: the script left HEAD on the next-wip bump commit, so a follow-up `dart pub publish` saw the `-wip` pubspec and offered to publish the wip version. (Easy to miss the version in the prompt — pre-release identifiers in semver versions look like normal version suffixes.)

Now after the bump commit, release.dart:
  - records the current branch
  - checks out the v$release tag (so pub publish reads the right tree)
  - runs `dart pub publish` with stdio inherited so pub.dev's own Y/N confirmation reaches the user's terminal
  - returns the working tree to the original branch

New flags: `--no-publish` to stop after the local commits, `--skip-tests` to skip `dart test` (e.g. when CI runs it separately). Existing `--next` and `--yes` unchanged.

CONTRIBUTING.md and PUBLICATION_CHECKLIST.md updated to reflect that the script now publishes by default.