### PR TITLE
docs: switch example + README to attributesFromSemanticMap shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-beta.5-wip]
 
+### Changed
+- README and the API example now use `OTelAPI.attributesFromSemanticMap({Enum.value: ...})` for typed-enum-keyed attribute maps in place of `OTelAPI.attributesFromMap({Enum.value.key: ...})` / `Attributes.of({Enum.value.key: ...})` / `<String, Object>{...}.toAttributes()`. The shorter form drops the `.key` accessor on every entry while keeping the typed-enum-key principle. Mixing different semconv enum types in one map is fine — the param is `Map<OTelSemantic, Object>` and every semconv enum implements `OTelSemantic`. No API surface change; `attributesFromSemanticMap` has existed since beta-era.
+
 ## [1.0.0-beta.4] - 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -261,14 +261,16 @@ void main() {
         ExampleAttribute.tags.key, ['payment', 'critical']),
   ]);
 
-  // Using Map extension — same enum-key principle.
-  Attributes fromMap = <String, Object>{
-    HttpResource.requestMethod.key: 'GET',
-    UrlResource.urlFull.key: 'https://api.example.com/users',
-    HttpResource.responseStatusCode.key: 200,
-    DeploymentResource.deploymentEnvironmentName.key: 'production',
-    UserSemantics.userRoles.key: ['admin', 'operator'],
-  }.toAttributes();
+  // Using attributesFromSemanticMap — same typed-enum principle, no
+  // `.key` accessor on each entry. Mixes any combination of
+  // OTel-spec semconv enums with your own ExampleAttribute-style enums.
+  Attributes fromMap = OTelAPI.attributesFromSemanticMap({
+    HttpResource.requestMethod: 'GET',
+    UrlResource.urlFull: 'https://api.example.com/users',
+    HttpResource.responseStatusCode: 200,
+    DeploymentResource.deploymentEnvironmentName: 'production',
+    UserSemantics.userRoles: ['admin', 'operator'],
+  });
 }
 ```
 
@@ -279,11 +281,11 @@ import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 
 final otelLoggerProvider = OTelAPI.loggerProvider();
 final otelLogger = otelLoggerProvider.getLogger('dart-otel-api-faux-db-service');
-final attrs = {
-  DatabaseResource.dbOperation.key: 'update',
-  DatabaseResource.dbCollectionName.key: 'orders',
-  DatabaseResource.dbResponseReturnedRows.key: 3,
-}.toAttributes();
+final attrs = OTelAPI.attributesFromSemanticMap({
+  DatabaseResource.dbOperation: 'update',
+  DatabaseResource.dbCollectionName: 'orders',
+  DatabaseResource.dbResponseReturnedRows: 3,
+});
 
 otelLogger.emit(
   eventName: 'order_update',

--- a/example/dartastic_opentelemetry_api_example.dart
+++ b/example/dartastic_opentelemetry_api_example.dart
@@ -88,18 +88,20 @@ void main() {
     final span = tracer.startSpan('doSomeExampleSpan');
     try {
       tracer.withSpan(span, () {
-        // Same thing as above, more simply but with some loss of type
-        // checking. If your Map has anything but the types above an
-        // exception will be thrown.
-        final equalToTheAbove = OTelAPI.attributesFromMap({
-          ExampleAttribute.exampleString.key: 'foo',
-          ExampleAttribute.exampleBool.key: true,
-          ExampleAttribute.exampleInt.key: 42,
-          ExampleAttribute.exampleDouble.key: 42.1,
-          ExampleAttribute.exampleStringList.key: ['foo', 'bar', 'baz'],
-          ExampleAttribute.exampleBoolList.key: [true, false, true],
-          ExampleAttribute.exampleIntList.key: [42, 43, 44],
-          ExampleAttribute.exampleDoubleList.key: [42.0, 42.1, 42.2],
+        // Same thing as above, more compactly. attributesFromSemanticMap
+        // takes the typed enum directly (no `.key` on each entry) and
+        // accepts any mix of OTelSemantic-implementing enums, including
+        // your own. Throws at construction if a value isn't a supported
+        // attribute type.
+        final equalToTheAbove = OTelAPI.attributesFromSemanticMap({
+          ExampleAttribute.exampleString: 'foo',
+          ExampleAttribute.exampleBool: true,
+          ExampleAttribute.exampleInt: 42,
+          ExampleAttribute.exampleDouble: 42.1,
+          ExampleAttribute.exampleStringList: ['foo', 'bar', 'baz'],
+          ExampleAttribute.exampleBoolList: [true, false, true],
+          ExampleAttribute.exampleIntList: [42, 43, 44],
+          ExampleAttribute.exampleDoubleList: [42.0, 42.1, 42.2],
         });
         span.attributes = equalToTheAbove;
         span.addEventNow(
@@ -129,9 +131,9 @@ void main() {
       eventName: 'user_login',
       severityNumber: Severity.INFO,
       body: 'User successfully logged in.',
-      attributes: Attributes.of({
-        UserSemantics.userId.key: 42,
-        ExampleAttribute.authMethod.key: 'password',
+      attributes: OTelAPI.attributesFromSemanticMap({
+        UserSemantics.userId: 42,
+        ExampleAttribute.authMethod: 'password',
       }),
     );
 
@@ -139,17 +141,17 @@ void main() {
       eventName: 'cache_miss',
       severityText: 'WARN',
       body: 'Cache miss for requested key.',
-      attributes: Attributes.of({
-        ExampleAttribute.cacheKey.key: 'profile_42',
-        ExampleAttribute.cacheRegion.key: 'us-east-1',
+      attributes: OTelAPI.attributesFromSemanticMap({
+        ExampleAttribute.cacheKey: 'profile_42',
+        ExampleAttribute.cacheRegion: 'us-east-1',
       }),
     );
 
-    final attrs = {
-      DatabaseResource.dbOperation.key: 'update',
-      DatabaseResource.dbCollectionName.key: 'orders',
-      DatabaseResource.dbResponseReturnedRows.key: 3,
-    }.toAttributes();
+    final attrs = OTelAPI.attributesFromSemanticMap({
+      DatabaseResource.dbOperation: 'update',
+      DatabaseResource.dbCollectionName: 'orders',
+      DatabaseResource.dbResponseReturnedRows: 3,
+    });
 
     logger.emit(
       eventName: 'order_update',
@@ -169,9 +171,9 @@ void main() {
         {'job': 'generate_thumbnails', 'status': 'ok'},
         {'job': 'sync_metadata', 'status': 'failed'},
       ],
-      attributes: Attributes.of({
-        ExampleAttribute.batchId.key: 'batch-2025-11-15-01',
-        ExampleAttribute.jobsTotal.key: 3,
+      attributes: OTelAPI.attributesFromSemanticMap({
+        ExampleAttribute.batchId: 'batch-2025-11-15-01',
+        ExampleAttribute.jobsTotal: 3,
       }),
     );
 
@@ -179,11 +181,11 @@ void main() {
       eventName: 'payment_failure',
       severityText: 'ERROR',
       body: 'Payment could not be processed.',
-      attributes: Attributes.of({
-        ExampleAttribute.paymentUserId.key: 101,
-        ExampleAttribute.paymentMethod.key: 'credit_card',
-        ExampleAttribute.paymentGateway.key: 'stripe',
-        ExampleAttribute.retryCount.key: 2,
+      attributes: OTelAPI.attributesFromSemanticMap({
+        ExampleAttribute.paymentUserId: 101,
+        ExampleAttribute.paymentMethod: 'credit_card',
+        ExampleAttribute.paymentGateway: 'stripe',
+        ExampleAttribute.retryCount: 2,
       }),
     );
   });


### PR DESCRIPTION
## Summary

Mirror of the SDK's PR #42 (`MindfulSoftwareLLC/dartastic_opentelemetry#42`). Updates the README and the API example to use `OTelAPI.attributesFromSemanticMap({Enum.value: ...})` instead of the longer forms (`OTelAPI.attributesFromMap({Enum.value.key: ...})`, `Attributes.of({Enum.value.key: ...})`, and `<String, Object>{...}.toAttributes()`).

`OTelAPI.attributesFromSemanticMap` has existed since the beta era — this PR is purely a docs/example update. No API surface change.

## Why this isn't true `.serverAddress` dot-shorthand

`attributesFromSemanticMap` takes `Map<OTelSemantic, Object>` — an interface every semconv enum implements, *not* a concrete enum type — so even with Dart 3.10's static dot-shorthand, the call site can't infer which concrete enum a bare `.requestMethod` would refer to. Dropping `.key` is the closest practical shortening that preserves typed-enum keys + multi-enum mixing in one map.

## Changes

- **README**: 2 maps converted (the typed-key example under "Working with attributes" and the typed-key example under "Working with logging").
- **example/dartastic_opentelemetry_api_example.dart**: 4 maps converted (the span attributes, two `logger.emit` attribute maps, and the `attrs` local that previously used the `Map.toAttributes()` extension).
- Comments updated where the old form was being explicitly described, so the prose still matches the code.

## Test plan

- [x] `dart analyze example/` clean.
- [x] `dart format` clean.
- [ ] CI matrix passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)