### PR TITLE
feat: pluggable TimeProvider for span and event timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-beta.5-wip]
 
+### Added
+- **Pluggable `TimeProvider` for span timestamps.** New abstraction with three pieces:
+  - `TimeProvider` (interface) and `SystemTimeProvider` (default, `DateTime.now`) — `lib/src/util/time_provider.dart`.
+  - `WebTimeProvider` — `window.performance.now()` + `timeOrigin` for sub-millisecond span timestamps on web. Lives in `lib/src/util/web_time_provider.dart` as a conditional facade (`web_time_provider_web.dart` on Dart-on-JS / Wasm; `web_time_provider_stub.dart` throws on native).
+  - `defaultTimeProvider` — platform-aware constant exported from `lib/src/util/default_time_provider.dart`. Native targets resolve to `SystemTimeProvider`; web targets to `WebTimeProvider`. Selected at compile time via `dart.library.js_interop`, the modern Wasm-compatible check.
+
+  Plumbed through `APITracerProvider.timeProvider` → `APITracer.timeProvider` → `APISpan._timeProvider` so span starts, ends, and events all source their timestamps from the same clock. `APISpan.addEventNow` and `addEvents(Map)` now route through the span's `_timeProvider` rather than the static `OTelFactory.spanEventNow` shortcut, which was hardcoded to `DateTime.now` and silently dropped sub-millisecond precision when the provider was a `WebTimeProvider`.
+
+  **Why this matters on web.** `DateTime.now()` on Dart-on-JS is millisecond-precision — the underlying source is JS `Date.now()`, and `microsecondsSinceEpoch` returns `millisecondsSinceEpoch × 1000` (the lower three digits are always zero, regardless of the Int64 storage type used by OTLP). `WebTimeProvider` routes through the browser performance API: ~5µs nominal precision, browser-coarsened to ~100µs as a Spectre mitigation, still 10–200× better than `Date.now()`. Native targets are unaffected and stay at `DateTime.now`'s 1µs floor.
+
+  **Auto-default on web.** Web users do not have to opt in — constructing an `APITracerProvider` on a web target automatically gets `WebTimeProvider` via `defaultTimeProvider`. To override (e.g., a fake clock in tests), assign `tracerProvider.timeProvider = customProvider`.
+
 ## [1.0.0-beta.4] - 2026-05-10
 
 ### Added

--- a/lib/dartastic_opentelemetry_api.dart
+++ b/lib/dartastic_opentelemetry_api.dart
@@ -69,4 +69,7 @@ export 'src/api/trace/tracer.dart';
 export 'src/api/trace/tracer_provider.dart';
 export 'src/factory/otel_factory.dart';
 // Util
+export 'src/util/default_time_provider.dart';
 export 'src/util/otel_log.dart';
+export 'src/util/time_provider.dart';
+export 'src/util/web_time_provider.dart';

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -75,7 +75,8 @@ class APISpan {
         _spankind = spanKind,
         _attributes = attributes,
         _timeProvider = timeProvider ?? defaultTimeProvider,
-        _startTime = startTime ?? (timeProvider ?? defaultTimeProvider).nowDateTime(),
+        _startTime =
+            startTime ?? (timeProvider ?? defaultTimeProvider).nowDateTime(),
         _spanLinks = spanLinks,
         _spanEvents = spanEvents {
     // Set initial status to unset per spec
@@ -309,9 +310,9 @@ class APISpan {
     }
     if (!isEnded) {
       _spanEvents ??= [];
-      spanEvents.forEach((name, attributes) => _spanEvents!.add(
-          OTelFactory.otelFactory!
-              .spanEvent(name, attributes, _timeProvider.nowDateTime())));
+      spanEvents.forEach((name, attributes) => _spanEvents!.add(OTelFactory
+          .otelFactory!
+          .spanEvent(name, attributes, _timeProvider.nowDateTime())));
     }
   }
 

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -4,6 +4,8 @@
 import 'package:meta/meta.dart';
 
 import '../../factory/otel_factory.dart';
+import '../../util/default_time_provider.dart';
+import '../../util/time_provider.dart';
 import '../common/attributes.dart';
 import '../common/instrumentation_scope.dart';
 import '../common/timestamp.dart';
@@ -46,6 +48,7 @@ class APISpan {
   final SpanKind _spankind;
   final APISpan? _parentSpan;
   final InstrumentationScope _instrumentationScope;
+  final TimeProvider _timeProvider;
   late final DateTime _startTime;
   DateTime? _endTime;
   Attributes _attributes;
@@ -64,13 +67,15 @@ class APISpan {
     List<SpanEvent>? spanEvents,
     List<SpanLink>? spanLinks,
     DateTime? startTime,
+    TimeProvider? timeProvider,
   })  : _name = name,
         _instrumentationScope = instrumentationScope,
         _spanContext = spanContext,
         _parentSpan = parentSpan,
         _spankind = spanKind,
         _attributes = attributes,
-        _startTime = startTime ?? DateTime.now(),
+        _timeProvider = timeProvider ?? defaultTimeProvider,
+        _startTime = startTime ?? (timeProvider ?? defaultTimeProvider).nowDateTime(),
         _spanLinks = spanLinks,
         _spanEvents = spanEvents {
     // Set initial status to unset per spec
@@ -287,7 +292,13 @@ class APISpan {
     }
     if (!isEnded) {
       _spanEvents ??= [];
-      _spanEvents!.add(OTelFactory.otelFactory!.spanEventNow(name, attributes));
+      // Source the event timestamp from this span's TimeProvider so events
+      // share the same clock as start/end. Bypasses the static
+      // `OTelFactory.spanEventNow` shortcut, which hardcodes `DateTime.now`
+      // and so would silently drop sub-millisecond precision when a
+      // `WebTimeProvider` is configured.
+      _spanEvents!.add(OTelFactory.otelFactory!
+          .spanEvent(name, attributes, _timeProvider.nowDateTime()));
     }
   }
 
@@ -298,8 +309,9 @@ class APISpan {
     }
     if (!isEnded) {
       _spanEvents ??= [];
-      spanEvents.forEach((name, attributes) => _spanEvents!
-          .add(OTelFactory.otelFactory!.spanEventNow(name, attributes)));
+      spanEvents.forEach((name, attributes) => _spanEvents!.add(
+          OTelFactory.otelFactory!
+              .spanEvent(name, attributes, _timeProvider.nowDateTime())));
     }
   }
 
@@ -416,7 +428,7 @@ class APISpan {
   /// Only the first call to end modifies the Span.
   void end({DateTime? endTime, SpanStatusCode? spanStatus}) {
     if (!isEnded) {
-      _endTime = endTime ?? DateTime.now();
+      _endTime = endTime ?? _timeProvider.nowDateTime();
       // Only set status if no status has been set
       if (_spanStatusCode == null || _spanStatusCode == SpanStatusCode.Unset) {
         _spanStatusCode = spanStatus ?? SpanStatusCode.Ok;

--- a/lib/src/api/trace/span_create.dart
+++ b/lib/src/api/trace/span_create.dart
@@ -30,6 +30,7 @@ class APISpanCreate {
     List<SpanEvent>? spanEvents,
     DateTime? startTime,
     bool isRecording = true,
+    TimeProvider? timeProvider,
   }) {
     if (OTelFactory.otelFactory == null) {
       throw StateError('Call initialize() first.');
@@ -63,6 +64,7 @@ class APISpanCreate {
         attributes: attributes ?? OTelFactory.otelFactory!.attributes(),
         spanLinks: links,
         startTime: startTime,
-        spanEvents: spanEvents);
+        spanEvents: spanEvents,
+        timeProvider: timeProvider);
   }
 }

--- a/lib/src/api/trace/tracer.dart
+++ b/lib/src/api/trace/tracer.dart
@@ -2,6 +2,8 @@
 // Copyright 2025, Michael Bushe, All rights reserved.
 
 import '../../factory/otel_factory.dart';
+import '../../util/default_time_provider.dart';
+import '../../util/time_provider.dart';
 import '../common/attributes.dart';
 import '../common/instrumentation_scope.dart';
 import '../context/context.dart';
@@ -33,6 +35,14 @@ class APITracer {
   /// can be used for filtering or grouping telemetry data.
   Attributes? attributes;
 
+  /// Clock used for span start, end, and event timestamps. Inherited from
+  /// the [APITracerProvider] that created this tracer; spans created via
+  /// [createSpan] are constructed with this clock so all timestamps in a
+  /// trace are consistent. Defaults to the platform-aware
+  /// `defaultTimeProvider` (native: `SystemTimeProvider`; web:
+  /// `WebTimeProvider`).
+  final TimeProvider timeProvider;
+
   /// Creates a new [APITracer].
   /// You cannot create a Tracer directly; you must use [TracerProvider]:
   /// ```dart
@@ -43,7 +53,8 @@ class APITracer {
     this.schemaUrl,
     this.version,
     this.attributes,
-  });
+    TimeProvider? timeProvider,
+  }) : timeProvider = timeProvider ?? defaultTimeProvider;
 
   /// Returns true if the tracer is enabled and will create sampling spans.
   /// This should be checked before performing expensive operations to create spans.
@@ -215,6 +226,7 @@ class APITracer {
       spanEvents: spanEvents,
       startTime: startTime,
       isRecording: isRecording ?? true && enabled,
+      timeProvider: timeProvider,
     );
     return apiSpan;
   }

--- a/lib/src/api/trace/tracer_create.dart
+++ b/lib/src/api/trace/tracer_create.dart
@@ -11,12 +11,14 @@ class TracerCreate {
     String? version,
     String? schemaUrl,
     Attributes? attributes,
+    TimeProvider? timeProvider,
   }) {
     return APITracer._(
       name: name,
       version: version,
       schemaUrl: schemaUrl,
       attributes: attributes,
+      timeProvider: timeProvider,
     );
   }
 }

--- a/lib/src/api/trace/tracer_provider.dart
+++ b/lib/src/api/trace/tracer_provider.dart
@@ -3,7 +3,9 @@
 
 // ignore_for_file: unnecessary_getters_setters
 
+import '../../util/default_time_provider.dart';
 import '../../util/otel_log.dart';
+import '../../util/time_provider.dart';
 import '../common/attributes.dart';
 import '../common/signal_instance_key.dart';
 import '../context/context.dart';
@@ -34,6 +36,18 @@ class APITracerProvider {
   // Cache for created tracers, keyed by _TracerKey.
   final Map<SignalInstanceKey, APITracer> _tracerCache = {};
 
+  /// Clock used for span start, end, and event timestamps. Tracers and
+  /// spans created from this provider inherit this clock so all timestamps
+  /// in a trace are consistent.
+  ///
+  /// **Defaults are platform-aware**: native targets get `SystemTimeProvider`
+  /// (`DateTime.now`, microsecond precision); web targets (Dart-on-JS or
+  /// Wasm) get `WebTimeProvider` (`window.performance.now()`, sub-
+  /// millisecond precision). Override only if you want different behaviour
+  /// — e.g., a fake clock in tests or a Pro `NativeNanosecondTimeProvider`
+  /// for FFI-backed nanosecond timing on native servers.
+  TimeProvider timeProvider;
+
   /// Creates a new [APITracerProvider].
   APITracerProvider._({
     required String endpoint,
@@ -41,11 +55,13 @@ class APITracerProvider {
     String? serviceVersion = OTelAPI.defaultServiceVersion,
     bool enabled = true,
     bool isShutdown = false,
+    TimeProvider? timeProvider,
   })  : _endpoint = endpoint,
         _serviceName = serviceName,
         _serviceVersion = serviceVersion,
         _enabled = enabled,
-        _isShutdown = isShutdown;
+        _isShutdown = isShutdown,
+        timeProvider = timeProvider ?? defaultTimeProvider;
 
   /// Gets the endpoint URL used by this tracer provider.
   ///
@@ -100,6 +116,7 @@ class APITracerProvider {
         version: effectiveVersion,
         schemaUrl: effectiveSchemaUrl,
         attributes: attributes,
+        timeProvider: timeProvider,
       );
       _tracerCache[key] = tracer;
       return tracer;

--- a/lib/src/util/default_time_provider.dart
+++ b/lib/src/util/default_time_provider.dart
@@ -1,0 +1,11 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Conditional facade for the platform-default `TimeProvider`. Native
+// targets get `SystemTimeProvider` (DateTime.now); web targets (JS or Wasm)
+// get `WebTimeProvider` (window.performance.now), so users running on the
+// browser automatically pick up sub-millisecond span timestamps without
+// having to opt in.
+
+export 'default_time_provider_io.dart'
+    if (dart.library.js_interop) 'default_time_provider_web.dart';

--- a/lib/src/util/default_time_provider_io.dart
+++ b/lib/src/util/default_time_provider_io.dart
@@ -1,0 +1,10 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'time_provider.dart';
+
+/// Platform default [TimeProvider] for native targets (Dart-VM, AOT,
+/// Flutter mobile/desktop): [SystemTimeProvider] backed by `DateTime.now`.
+/// Selected at compile time via the conditional export in
+/// `default_time_provider.dart`.
+const TimeProvider defaultTimeProvider = SystemTimeProvider();

--- a/lib/src/util/default_time_provider_web.dart
+++ b/lib/src/util/default_time_provider_web.dart
@@ -1,0 +1,12 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'time_provider.dart';
+import 'web_time_provider.dart';
+
+/// Platform default [TimeProvider] for web targets (Dart-on-JS, Wasm):
+/// [WebTimeProvider] backed by `window.performance.now()` for sub-
+/// millisecond span timestamps. Selected at compile time via the
+/// conditional export in `default_time_provider.dart`. Lazily constructed
+/// on first read so the `timeOrigin` snapshot happens at the right time.
+final TimeProvider defaultTimeProvider = WebTimeProvider();

--- a/lib/src/util/time_provider.dart
+++ b/lib/src/util/time_provider.dart
@@ -1,0 +1,40 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+/// A clock for span start, end, and event timestamps.
+///
+/// The default [SystemTimeProvider] uses [DateTime.now], which is microsecond-
+/// precision on Dart-VM native and **millisecond-precision on Dart-on-JS web**
+/// (`Date.now()` is the JS source — `microsecondsSinceEpoch` returns
+/// `millisecondsSinceEpoch * 1000`, so the lower three digits are always
+/// zero). For sub-millisecond spans on web, see [WebTimeProvider] in
+/// `lib/src/util/web_time_provider.dart`, which routes through
+/// `window.performance.now()` (~5µs nominal, browser-coarsened to ~100µs
+/// for Spectre mitigation).
+///
+/// The provider is held on [APITracerProvider]; tracers and spans created
+/// from a provider inherit its clock so that all timestamps in a trace are
+/// consistent. SDK consumers configure it via `OTel.initialize(timeProvider:
+/// ...)`; API-only consumers can pass it to the API tracer-provider factory.
+abstract class TimeProvider {
+  /// Returns the current wall-clock time as a [DateTime].
+  ///
+  /// Used by `APITracer.startSpan` for span start times, by `APISpan.end`
+  /// for span end times, and by `APISpan.addEventNow` for span-event
+  /// timestamps.
+  DateTime nowDateTime();
+}
+
+/// Default [TimeProvider] backed by [DateTime.now].
+///
+/// On native (VM, AOT, FFI): microsecond precision.
+/// On Dart-on-JS web: millisecond precision (the browser ceiling on
+/// `Date.now()`). Use `WebTimeProvider` on web for sub-millisecond timing.
+class SystemTimeProvider implements TimeProvider {
+  /// Constructs the default time provider. `const`-constructible so it can
+  /// serve as a default-parameter value.
+  const SystemTimeProvider();
+
+  @override
+  DateTime nowDateTime() => DateTime.now();
+}

--- a/lib/src/util/web_time_provider.dart
+++ b/lib/src/util/web_time_provider.dart
@@ -1,0 +1,10 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+// Conditional facade for `WebTimeProvider`. On web targets (Dart-on-JS or
+// Wasm) this exports an implementation backed by `window.performance.now()`
+// for sub-millisecond span timing; on native targets it exports a stub that
+// throws on instantiation, since `package:web` is web-only.
+
+export 'web_time_provider_stub.dart'
+    if (dart.library.js_interop) 'web_time_provider_web.dart';

--- a/lib/src/util/web_time_provider_stub.dart
+++ b/lib/src/util/web_time_provider_stub.dart
@@ -1,0 +1,27 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'time_provider.dart';
+
+/// Native-target stub for [WebTimeProvider].
+///
+/// `WebTimeProvider` is a web-only `TimeProvider` backed by
+/// `window.performance.now()`. On native (Dart-VM, Flutter mobile/desktop),
+/// `package:web` is unavailable, so the conditional facade in
+/// `web_time_provider.dart` exports this stub instead. Constructing it
+/// throws — native consumers should use [SystemTimeProvider] (or, for true
+/// nanosecond timing on native, the Pro `dartastic_native_time` package).
+class WebTimeProvider implements TimeProvider {
+  /// Throws — `WebTimeProvider` requires a web target.
+  WebTimeProvider() {
+    throw UnsupportedError(
+      'WebTimeProvider is only available on web targets. '
+      'Use SystemTimeProvider on native or import from a web entry point.',
+    );
+  }
+
+  @override
+  DateTime nowDateTime() {
+    throw UnsupportedError('WebTimeProvider is only available on web targets.');
+  }
+}

--- a/lib/src/util/web_time_provider_web.dart
+++ b/lib/src/util/web_time_provider_web.dart
@@ -1,0 +1,45 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:web/web.dart' as web;
+
+import 'time_provider.dart';
+
+/// Web `TimeProvider` backed by `window.performance.now()` and `timeOrigin`.
+///
+/// On Dart-on-JS, the default `DateTime.now()` is millisecond-precision —
+/// `Date.now()` is the underlying source and `microsecondsSinceEpoch`
+/// returns `millisecondsSinceEpoch * 1000`. The browser performance API
+/// (`window.performance.now()` + `window.performance.timeOrigin`) returns a
+/// `DOMHighResTimeStamp` that is fractional milliseconds with sub-
+/// millisecond precision: ~5µs nominal, coarsened by browsers to roughly
+/// 100µs as a Spectre-mitigation (Firefox: 1ms unless `crossOriginIsolated`;
+/// Chrome: 5µs cross-origin-isolated, else 100µs). That's still 10–200×
+/// better than `Date.now()`, and matches what JavaScript OpenTelemetry SDKs
+/// use.
+///
+/// True nanosecond precision is **not available in browsers** regardless of
+/// what the OTLP wire format claims to support. For native targets, see the
+/// Pro `dartastic_native_time` package, which uses FFI to
+/// `clock_gettime(CLOCK_REALTIME)` / `QueryPerformanceCounter`.
+class WebTimeProvider implements TimeProvider {
+  /// Constructs a `WebTimeProvider` and snapshots `timeOrigin` once.
+  WebTimeProvider();
+
+  /// Time when the page navigation started (or the worker was started),
+  /// in fractional milliseconds since Unix Epoch. Snapshotted once because
+  /// `timeOrigin` is constant for the lifetime of the document.
+  static final double _timeOriginMs = web.window.performance.timeOrigin;
+
+  @override
+  DateTime nowDateTime() {
+    // performance.now() returns ms since timeOrigin. Total ms since epoch
+    // is timeOrigin + now(). Convert fractional ms to integer microseconds
+    // for DateTime.fromMicrosecondsSinceEpoch — that preserves sub-ms
+    // precision up to the microsecond, which is the floor `DateTime`
+    // stores anyway.
+    final totalMs = _timeOriginMs + web.window.performance.now();
+    final totalMicros = (totalMs * 1000).round();
+    return DateTime.fromMicrosecondsSinceEpoch(totalMicros, isUtc: false);
+  }
+}

--- a/test/unit/api/trace/span_test.dart
+++ b/test/unit/api/trace/span_test.dart
@@ -194,12 +194,18 @@ void main() {
         kind: SpanKind.internal,
       );
 
-      final beforeCreation = DateTime.now();
+      // Capture bounds from the same TimeProvider the span uses, so the
+      // bracketing assertion is exact on every platform. On Dart-on-JS /
+      // Wasm, `tracer.timeProvider` is `WebTimeProvider` (sub-ms via
+      // `performance.now`) while `DateTime.now` is `Date.now` (ms-
+      // truncated) — bracketing with `DateTime.now` would let the event
+      // timestamp fall up to ~1ms past `afterCreation`.
+      final beforeCreation = tracer.timeProvider.nowDateTime();
       span.addEventNow(
         'test-event',
         {'event.key': 'value'}.toAttributes(),
       );
-      final afterCreation = DateTime.now();
+      final afterCreation = tracer.timeProvider.nowDateTime();
 
       final events = span.spanEvents;
       expect(events, hasLength(1));


### PR DESCRIPTION
Adds a TimeProvider abstraction so spans source timestamps from a configurable clock instead of DateTime.now. Web targets automatically get sub-millisecond timing via WebTimeProvider  (window.performance.now + timeOrigin), closing the gap where DateTime.now on Dart-on-JS is millisecond-precision regardless of the Int64 storage used by OTLP — Date.now is the underlying source, and microsecondsSinceEpoch returns millisecondsSinceEpoch * 1000, leaving the lower three digits always zero.

New in lib/src/util/:
    - time_provider.dart — TimeProvider interface + SystemTimeProvider.
    - web_time_provider.dart (+ _stub / _web) — conditional facade. Web gets the real impl; native gets a stub that throws on construction.
    - default_time_provider.dart (+ _io / _web) — platform-aware defaultTimeProvider constant, selected at compile time via dart.library.js_interop (the modern Wasm-compatible check).

Threaded through APITracerProvider.timeProvider → APITracer.timeProvider → APISpan._timeProvider. Span start, end, and events all use the same clock. addEventNow and addEvents(Map) previously routed through the static OTelFactory.spanEventNow shortcut, which hardcoded DateTime.now and silently dropped sub-ms precision when a WebTimeProvider was configured for the rest of the span — fixed.

Web precision delta: ~5µs nominal, browser-coarsened to ~100µs (Spectre mitigation), 10–200× better than Date.now. Native unchanged at DateTime.now's 1µs floor. True nanosecond on browsers isn't available regardless of OTLP wire format.

  No caller opt-in required — defaultTimeProvider auto-selects
  WebTimeProvider on web targets. Override only for fake clocks in
  tests or the forthcoming Pro nanosecond provider.