### PR TITLE
fix: Context getters no longer throw before OTelAPI.initialize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-beta.8-wip]
 
+### Fixed
+- `Context.root` / `Context.current` (and other Context APIs) threw
+  `StateError('Call initialize() first.')` when accessed before
+  `OTelAPI.initialize()`, violating the OTel spec requirement that the API
+  operate as a no-op without an SDK installed. They now lazily install the
+  No-Op API factory, matching `OTelAPI`'s existing behavior.
+
 ## [1.0.0-beta.7] - 2026-05-18
 
 ## [1.0.0-beta.6] - 2026-05-11

--- a/lib/src/api/context/context.dart
+++ b/lib/src/api/context/context.dart
@@ -40,16 +40,12 @@ class Context {
 
   /// Gets and caches the OTelFactory instance.
   ///
-  /// Retrieves the global OTelFactory instance and caches it for future use.
-  /// Throws a StateError if OpenTelemetry has not been initialized.
+  /// Retrieves the global OTelFactory instance, lazily installing the No-Op
+  /// API factory if no SDK has installed one yet, and caches it for future
+  /// use. Per the OpenTelemetry specification, the API MUST NOT require
+  /// explicit initialization, so this never throws.
   static OTelFactory _getAndCacheOTelFactory() {
-    if (_otelFactory != null) {
-      return _otelFactory!;
-    }
-    if (OTelFactory.otelFactory == null) {
-      throw StateError('Call initialize() first.');
-    }
-    return _otelFactory = OTelFactory.otelFactory!;
+    return _otelFactory ??= OTelFactory.getOrCreateDefault();
   }
 
   /// Gets the current Context from the current Zone, or the global Context if none exists.

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -713,28 +713,11 @@ class OTelAPI {
   }
 
   static OTelFactory _getAndCacheOtelFactory() {
-    // Always check if a new (potentially better) factory has been installed
-    if (OTelFactory.otelFactory != null) {
-      // If we have a cached factory but a new one is available, update the cache
-      if (_otelFactory != OTelFactory.otelFactory) {
-        _otelFactory = OTelFactory.otelFactory;
-      }
-      return _otelFactory!;
-    }
-
-    // If no factory is installed, create the API factory (NoOp implementations)
-    if (_otelFactory == null) {
-      // According to OpenTelemetry spec, when no SDK is installed,
-      // the API should provide NoOp implementations automatically
-      OTelFactory.otelFactory = otelApiFactoryFactoryFunction(
-        apiEndpoint: OTelFactory.defaultEndpoint,
-        apiServiceName: defaultServiceName,
-        apiServiceVersion: defaultServiceVersion,
-      );
-      _otelFactory = OTelFactory.otelFactory;
-    }
-
-    return _otelFactory!;
+    // According to OpenTelemetry spec, when no SDK is installed, the API
+    // must provide NoOp implementations automatically rather than throwing.
+    // Always re-check the global in case a (potentially better) factory has
+    // since been installed by an SDK.
+    return _otelFactory = OTelFactory.getOrCreateDefault();
   }
 
   /// Reset API state (only public for testing)

--- a/lib/src/factory/otel_factory.dart
+++ b/lib/src/factory/otel_factory.dart
@@ -10,6 +10,7 @@ import '../api/common/attributes.dart';
 import '../api/common/instrumentation_scope.dart';
 import '../api/context/context.dart';
 import '../api/context/context_key.dart';
+import '../api/factory/otel_api_factory.dart';
 import '../api/logs/logger_provider.dart';
 import '../api/metrics/counter.dart';
 import '../api/metrics/gauge.dart';
@@ -50,6 +51,7 @@ abstract class OTelFactory {
   /// SDKs must replace this otelFactory with their own to get the SDK
   /// object created instead of the API default implementation
   static OTelFactory? otelFactory;
+
   String _apiEndpoint;
   String _apiServiceName;
   String _apiServiceVersion;
@@ -81,6 +83,21 @@ abstract class OTelFactory {
       : _apiServiceVersion = apiServiceVersion,
         _apiServiceName = apiServiceName,
         _apiEndpoint = apiEndpoint;
+
+  /// Returns the installed [otelFactory], lazily installing the No-Op API
+  /// factory if none has been installed yet.
+  ///
+  /// Per the OpenTelemetry specification, the API MUST NOT require explicit
+  /// initialization: calls made before an SDK is installed must operate as
+  /// no-ops rather than throwing. This is the single choke point that both
+  /// [OTelAPI] and [Context] rely on to satisfy that requirement.
+  static OTelFactory getOrCreateDefault() {
+    return otelFactory ??= otelApiFactoryFactoryFunction(
+      apiEndpoint: defaultEndpoint,
+      apiServiceName: OTelAPI.defaultServiceName,
+      apiServiceVersion: OTelAPI.defaultServiceVersion,
+    );
+  }
 
   /// Sets the API endpoint for this factory.
   ///

--- a/test/unit/api/context/context_uninitialized_test.dart
+++ b/test/unit/api/context/context_uninitialized_test.dart
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Regression test for https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/28
+//
+// Per the OpenTelemetry spec, the API MUST NOT require explicit
+// initialization: calls made before an SDK/API is installed must operate as
+// no-ops rather than throwing. This must run before any other test in the
+// process calls OTelAPI.initialize(), so it lives in its own file — the
+// `test` package runs each test file in its own isolate, giving a pristine
+// (uninitialized) copy of all library statics.
+void main() {
+  test('Context.current does not throw before OTelAPI.initialize() is called',
+      () {
+    expect(() => Context.current, returnsNormally);
+    expect(Context.current.span, isNull);
+    expect(Context.current.baggage, isNull);
+  });
+
+  test('Context.root does not throw before OTelAPI.initialize() is called',
+      () {
+    expect(() => Context.root, returnsNormally);
+  });
+
+  test('Context.current.withBaggage does not throw before initialization',
+      () {
+    final baggage = OTelAPI.baggageForMap({'key': 'value'});
+    expect(() => Context.current.withBaggage(baggage), returnsNormally);
+  });
+}


### PR DESCRIPTION
## Summary
- `Context.root`/`Context.current` (and anything that touches them, e.g. `withBaggage`) threw `StateError('Call initialize() first.')` when accessed before an SDK/API factory was installed, violating the [OTel spec requirement](https://opentelemetry.io/docs/specs/otel/library-guidelines/) that the API operate as a no-op without explicit initialization.
- Added `OTelFactory.getOrCreateDefault()` as the single choke point for lazily installing the No-Op API factory, and pointed `Context._getAndCacheOTelFactory()` at it.
- `OTelAPI._getAndCacheOtelFactory()` already had equivalent self-init logic; it now delegates to the same shared helper instead of duplicating it.

Fixes #28.

## Test plan
- [x] `dart analyze lib/ test/` — no issues
- [x] `dart test` — all tests pass
- [x] New regression test (`test/unit/api/context/context_uninitialized_test.dart`) added in its own file so it runs before any other test calls `OTelAPI.initialize()`; confirmed it reproduces the original `StateError` when the fix is reverted.