### PR TITLE
feat: add OTelFactory.isAPIFactory to identify the no-op API factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-beta.8-wip]
 
+### Added
+- **`OTelFactory.isAPIFactory`** — identifies the API's auto-installed no-op
+  factory. Defaults to `false` on `OTelFactory`; `OTelAPIFactory` overrides it
+  to `true`. SDK factories (which extend `OTelAPIFactory`) must override it to
+  return `false`. Lets SDK initialization replace the spec-mandated no-op API
+  factory installed when API code runs first, instead of relying on
+  `runtimeType` checks (see dartastic_opentelemetry #50 / PR #53).
+
 ## [1.0.0-beta.7] - 2026-05-18
 
 ## [1.0.0-beta.6] - 2026-05-11

--- a/lib/src/api/factory/otel_api_factory.dart
+++ b/lib/src/api/factory/otel_api_factory.dart
@@ -72,6 +72,15 @@ class OTelAPIFactory extends OTelFactory {
           otelApiFactoryFactoryFunction})
       : super(factoryFactory: factoryFactory!);
 
+  /// The pure API factory is the spec-mandated no-op used when no SDK is
+  /// installed; SDK initialization may replace it.
+  ///
+  /// SDK factories extend [OTelAPIFactory], so a real implementation MUST
+  /// override this to return `false` — otherwise SDK initialization would
+  /// treat it as replaceable.
+  @override
+  bool get isAPIFactory => true;
+
   @override
   BaggageEntry baggageEntry(String value, [String? metadata]) {
     return BaggageEntryFactory.create<String>(value, metadata);

--- a/lib/src/factory/otel_factory.dart
+++ b/lib/src/factory/otel_factory.dart
@@ -82,6 +82,17 @@ abstract class OTelFactory {
         _apiServiceName = apiServiceName,
         _apiEndpoint = apiEndpoint;
 
+  /// Whether this factory is the API's no-op factory rather than a real
+  /// (SDK) implementation.
+  ///
+  /// The API auto-installs its no-op [OTelAPIFactory] when API code runs
+  /// before an SDK initializes (per the OpenTelemetry specification). SDKs
+  /// use this flag to recognize that auto-installed no-op factory and
+  /// replace it during SDK initialization, while refusing to replace a
+  /// real factory. Defaults to `false`: a factory is assumed to be a real
+  /// implementation unless it declares otherwise.
+  bool get isAPIFactory => false;
+
   /// Sets the API endpoint for this factory.
   ///
   /// This determines where telemetry data will be sent when using SDK implementations.

--- a/test/unit/api/factory/otel_api_factory_test.dart
+++ b/test/unit/api/factory/otel_api_factory_test.dart
@@ -48,8 +48,7 @@ void main() {
       expect(direct.isAPIFactory, isTrue);
     });
 
-    test('isAPIFactory can be overridden to false by SDK-style subclasses',
-        () {
+    test('isAPIFactory can be overridden to false by SDK-style subclasses', () {
       final sdkStyle = _FakeSDKFactory(
         apiEndpoint: 'http://localhost:4317',
         apiServiceName: 'test-service',

--- a/test/unit/api/factory/otel_api_factory_test.dart
+++ b/test/unit/api/factory/otel_api_factory_test.dart
@@ -35,6 +35,29 @@ void main() {
       expect(factory, isA<OTelAPIFactory>());
     });
 
+    test('isAPIFactory is true for the installed API factory', () {
+      expect(factory.isAPIFactory, isTrue);
+    });
+
+    test('isAPIFactory is true for a directly-constructed OTelAPIFactory', () {
+      final direct = OTelAPIFactory(
+        apiEndpoint: 'http://localhost:4317',
+        apiServiceName: 'test-service',
+        apiServiceVersion: '1.0.0',
+      );
+      expect(direct.isAPIFactory, isTrue);
+    });
+
+    test('isAPIFactory can be overridden to false by SDK-style subclasses',
+        () {
+      final sdkStyle = _FakeSDKFactory(
+        apiEndpoint: 'http://localhost:4317',
+        apiServiceName: 'test-service',
+        apiServiceVersion: '1.0.0',
+      );
+      expect(sdkStyle.isAPIFactory, isFalse);
+    });
+
     test('creates baggage entry', () {
       final entry = factory.baggageEntry('test-value', 'test-metadata');
       expect(entry.value, equals('test-value'));
@@ -480,4 +503,18 @@ void main() {
       expect(observableUpDownCounter.unit, equals('count'));
     });
   });
+}
+
+/// Simulates an SDK factory: real factories extend [OTelAPIFactory] and must
+/// override [OTelAPIFactory.isAPIFactory] so SDK initialization does not
+/// treat them as the replaceable no-op API factory.
+class _FakeSDKFactory extends OTelAPIFactory {
+  _FakeSDKFactory({
+    required super.apiEndpoint,
+    required super.apiServiceName,
+    required super.apiServiceVersion,
+  });
+
+  @override
+  bool get isAPIFactory => false;
 }

--- a/test/unit/factory/otel_factory_test.dart
+++ b/test/unit/factory/otel_factory_test.dart
@@ -15,6 +15,12 @@ void main() {
       );
     });
 
+    test('installed API factory reports isAPIFactory', () {
+      // The SDK's initialize() uses this flag to recognize the auto-installed
+      // no-op API factory as replaceable.
+      expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+    });
+
     test('globalDefaultTracerProvider returns the same instance', () {
       final factory = OTelFactory.otelFactory!;
       final provider1 = factory.globalDefaultTracerProvider();

--- a/tool/release.dart
+++ b/tool/release.dart
@@ -675,4 +675,3 @@ Never _die(String msg) {
   stderr.writeln('error: $msg');
   exit(1);
 }
-


### PR DESCRIPTION
## Summary

Adds the `isAPIFactory` getter agreed on in [dartastic_opentelemetry#53](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/pull/53) (fixing [dartastic_opentelemetry#50](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry/issues/50)).

The SDK needs to distinguish the API's auto-installed no-op `OTelAPIFactory` (replaceable by `OTel.initialize()`) from real SDK factories (not replaceable). Since every factory — `OTelSDKFactory`, `OTelFlutterFactory`, custom factories — extends `OTelAPIFactory`, an `is` check matches them all, forcing the SDK into `runtimeType != OTelAPIFactory` checks. This getter replaces that.

## Changes

- **`OTelFactory`**: `bool get isAPIFactory => false;` — a factory is assumed to be a real implementation unless it declares otherwise.
- **`OTelAPIFactory`**: overrides to `true`, with docs stating that SDK factories (which extend `OTelAPIFactory`) MUST override it back to `false` — otherwise SDK initialization would treat them as replaceable.
- **Tests**: installed factory reports `true`; a directly-constructed `OTelAPIFactory` reports `true`; an SDK-style subclass overriding to `false` reports `false` (verifies the override path through inheritance); the globally installed `OTelFactory.otelFactory` is recognizable as the API no-op — the exact check the SDK's `OTel.initialize()` will make.
- **CHANGELOG**: entry under `[1.0.0-beta.8-wip]`.

## Follow-up (SDK repo)

`dartastic_opentelemetry` PR #53 can then override `isAPIFactory => false` in `OTelSDKFactory` and switch its `initialize()` / `_getAndCacheOtelFactory` guards to `!isAPIFactory`.

## Validation

- `dart analyze` — clean
- `dart test` — 729 tests passing (725 baseline + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)