### PR TITLE
fix: Context works as a no-op before initialization and stays upgradeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   factory installed when API code runs first, instead of relying on
   `runtimeType` checks (see dartastic_opentelemetry #50 / PR #53).
 
+### Fixed
+- `Context.root` / `Context.current` (and other Context APIs) threw
+  `StateError('Call initialize() first.')` when accessed before
+  `OTelAPI.initialize()`, violating the OTel spec requirement that the API
+  operate as a no-op without an SDK installed. They now lazily install the
+  No-Op API factory, matching `OTelAPI`'s existing behavior.
+
 ## [1.0.0-beta.7] - 2026-05-18
 
 ## [1.0.0-beta.6] - 2026-05-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `StateError('Call initialize() first.')` when accessed before
   `OTelAPI.initialize()`, violating the OTel spec requirement that the API
   operate as a no-op without an SDK installed. They now lazily install the
-  No-Op API factory, matching `OTelAPI`'s existing behavior.
+  No-Op API factory, matching `OTelAPI`'s existing behavior. Thanks
+  @benjaben.
+- `Context` re-reads the global factory on every access instead of keeping
+  the first one it saw, so a factory installed later (e.g. by an SDK's
+  `initialize()`) replaces a no-op cached before initialization.
+- `OTelAPI.initialize()` now replaces an installed no-op API factory
+  (`isAPIFactory == true`) instead of throwing, so API use before
+  initialization (e.g. `Context.current`) no longer blocks explicit
+  initialization. **Behavior change:** re-initializing over a no-op API
+  factory replaces it and applies the new configuration; only a real
+  (non-API) factory still triggers the initialize-once `StateError`.
 
 ## [1.0.0-beta.7] - 2026-05-18
 

--- a/lib/src/api/context/context.dart
+++ b/lib/src/api/context/context.dart
@@ -41,11 +41,13 @@ class Context {
   /// Gets and caches the OTelFactory instance.
   ///
   /// Retrieves the global OTelFactory instance, lazily installing the No-Op
-  /// API factory if no SDK has installed one yet, and caches it for future
-  /// use. Per the OpenTelemetry specification, the API MUST NOT require
-  /// explicit initialization, so this never throws.
+  /// API factory if no SDK has installed one yet. Per the OpenTelemetry
+  /// specification, the API MUST NOT require explicit initialization, so this
+  /// never throws. The global is re-read on every call — like [OTelAPI] —
+  /// so a factory installed later (e.g. by an SDK's initialize()) replaces
+  /// any no-op cached before initialization.
   static OTelFactory _getAndCacheOTelFactory() {
-    return _otelFactory ??= OTelFactory.getOrCreateDefault();
+    return _otelFactory = OTelFactory.getOrCreateDefault();
   }
 
   /// Gets the current Context from the current Zone, or the global Context if none exists.

--- a/lib/src/api/context/context.dart
+++ b/lib/src/api/context/context.dart
@@ -40,16 +40,12 @@ class Context {
 
   /// Gets and caches the OTelFactory instance.
   ///
-  /// Retrieves the global OTelFactory instance and caches it for future use.
-  /// Throws a StateError if OpenTelemetry has not been initialized.
+  /// Retrieves the global OTelFactory instance, lazily installing the No-Op
+  /// API factory if no SDK has installed one yet, and caches it for future
+  /// use. Per the OpenTelemetry specification, the API MUST NOT require
+  /// explicit initialization, so this never throws.
   static OTelFactory _getAndCacheOTelFactory() {
-    if (_otelFactory != null) {
-      return _otelFactory!;
-    }
-    if (OTelFactory.otelFactory == null) {
-      throw StateError('Call initialize() first.');
-    }
-    return _otelFactory = OTelFactory.otelFactory!;
+    return _otelFactory ??= OTelFactory.getOrCreateDefault();
   }
 
   /// Gets the current Context from the current Zone, or the global Context if none exists.

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -713,28 +713,11 @@ class OTelAPI {
   }
 
   static OTelFactory _getAndCacheOtelFactory() {
-    // Always check if a new (potentially better) factory has been installed
-    if (OTelFactory.otelFactory != null) {
-      // If we have a cached factory but a new one is available, update the cache
-      if (_otelFactory != OTelFactory.otelFactory) {
-        _otelFactory = OTelFactory.otelFactory;
-      }
-      return _otelFactory!;
-    }
-
-    // If no factory is installed, create the API factory (NoOp implementations)
-    if (_otelFactory == null) {
-      // According to OpenTelemetry spec, when no SDK is installed,
-      // the API should provide NoOp implementations automatically
-      OTelFactory.otelFactory = otelApiFactoryFactoryFunction(
-        apiEndpoint: OTelFactory.defaultEndpoint,
-        apiServiceName: defaultServiceName,
-        apiServiceVersion: defaultServiceVersion,
-      );
-      _otelFactory = OTelFactory.otelFactory;
-    }
-
-    return _otelFactory!;
+    // According to OpenTelemetry spec, when no SDK is installed, the API
+    // must provide NoOp implementations automatically rather than throwing.
+    // Always re-check the global in case a (potentially better) factory has
+    // since been installed by an SDK.
+    return _otelFactory = OTelFactory.getOrCreateDefault();
   }
 
   /// Reset API state (only public for testing)

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 
 import '../factory/otel_factory.dart';
+import '../util/otel_log.dart';
 import 'baggage/baggage.dart';
 import 'baggage/baggage_entry.dart';
 import 'common/attribute.dart';
@@ -86,9 +87,20 @@ class OTelAPI {
       String? serviceName = OTelAPI.defaultServiceName,
       String? serviceVersion = OTelAPI.defaultServiceVersion,
       OTelFactoryCreationFunction? oTelFactoryCreationFunction}) {
-    if (OTelFactory.otelFactory != null) {
+    // The no-op API factory auto-installs when API code (e.g. Context.current)
+    // runs before initialize(), per spec. An installed API factory is
+    // replaceable — only a real (SDK) factory means initialization already
+    // happened and must not be silently discarded.
+    final existingFactory = OTelFactory.otelFactory;
+    if (existingFactory != null && !existingFactory.isAPIFactory) {
       throw StateError(
           'OTelAPI can only be initialized once. If you need multiple endpoints or service names or versions create a named TracerProvider');
+    }
+    if (existingFactory != null && OTelLog.isDebug()) {
+      OTelLog.debug(
+          'OTelAPI.initialize: replacing the installed no-op API factory '
+          'with the configured API factory. API objects obtained before '
+          'initialize() remain no-ops.');
     }
     if (endpoint.isEmpty) {
       throw ArgumentError(

--- a/lib/src/factory/otel_factory.dart
+++ b/lib/src/factory/otel_factory.dart
@@ -10,6 +10,7 @@ import '../api/common/attributes.dart';
 import '../api/common/instrumentation_scope.dart';
 import '../api/context/context.dart';
 import '../api/context/context_key.dart';
+import '../api/factory/otel_api_factory.dart';
 import '../api/logs/logger_provider.dart';
 import '../api/metrics/counter.dart';
 import '../api/metrics/gauge.dart';
@@ -50,6 +51,7 @@ abstract class OTelFactory {
   /// SDKs must replace this otelFactory with their own to get the SDK
   /// object created instead of the API default implementation
   static OTelFactory? otelFactory;
+
   String _apiEndpoint;
   String _apiServiceName;
   String _apiServiceVersion;
@@ -92,6 +94,21 @@ abstract class OTelFactory {
   /// real factory. Defaults to `false`: a factory is assumed to be a real
   /// implementation unless it declares otherwise.
   bool get isAPIFactory => false;
+
+  /// Returns the installed [otelFactory], lazily installing the No-Op API
+  /// factory if none has been installed yet.
+  ///
+  /// Per the OpenTelemetry specification, the API MUST NOT require explicit
+  /// initialization: calls made before an SDK is installed must operate as
+  /// no-ops rather than throwing. This is the single choke point that both
+  /// [OTelAPI] and [Context] rely on to satisfy that requirement.
+  static OTelFactory getOrCreateDefault() {
+    return otelFactory ??= otelApiFactoryFactoryFunction(
+      apiEndpoint: defaultEndpoint,
+      apiServiceName: OTelAPI.defaultServiceName,
+      apiServiceVersion: OTelAPI.defaultServiceVersion,
+    );
+  }
 
   /// Sets the API endpoint for this factory.
   ///

--- a/lib/src/factory/otel_factory.dart
+++ b/lib/src/factory/otel_factory.dart
@@ -102,6 +102,10 @@ abstract class OTelFactory {
   /// initialization: calls made before an SDK is installed must operate as
   /// no-ops rather than throwing. This is the single choke point that both
   /// [OTelAPI] and [Context] rely on to satisfy that requirement.
+  ///
+  /// The lazily created factory reports [isAPIFactory] as `true`, so a later
+  /// explicit initialization (API or SDK) recognizes it as replaceable and
+  /// upgrades it rather than failing as a double-initialization.
   static OTelFactory getOrCreateDefault() {
     return otelFactory ??= otelApiFactoryFactoryFunction(
       apiEndpoint: defaultEndpoint,

--- a/test/unit/api/context/context_factory_upgrade_test.dart
+++ b/test/unit/api/context/context_factory_upgrade_test.dart
@@ -1,0 +1,76 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'dart:typed_data';
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Companion to context_uninitialized_test.dart (issue #28).
+//
+// When Context lazily installs the no-op API factory before an SDK
+// initializes, it must not hold on to that no-op after the SDK replaces the
+// global factory. OTelAPI already re-reads OTelFactory.otelFactory on every
+// access for exactly this reason ("a potentially better factory may have
+// been installed"); Context must track the global the same way, or every
+// factory product Context creates (context keys, contexts) keeps coming
+// from the stale no-op — the same staleness class as
+// dartastic_opentelemetry issue #50.
+//
+// This must run before any other test in the process installs a factory, so
+// it lives in its own file — the `test` package runs each test file in its
+// own isolate, giving a pristine (uninitialized) copy of all library statics.
+void main() {
+  test(
+      'Context uses an SDK-installed factory after lazily installing the no-op',
+      () {
+    // Spec-permitted early API use: Context lazily installs (and caches) the
+    // no-op API factory.
+    expect(() => Context.current, returnsNormally);
+    expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+
+    // An SDK initializes: it replaces the replaceable no-op with its own
+    // factory, the documented upgrade mechanism on OTelFactory.otelFactory.
+    final sdkFactory = _RecordingFactory(
+      apiEndpoint: 'http://localhost:4318',
+      apiServiceName: 'sdk-service',
+      apiServiceVersion: '1.0.0',
+    );
+    OTelFactory.otelFactory = sdkFactory;
+
+    // OTelAPI re-reads the global and picks up the new factory.
+    OTelAPI.contextKey<String>('via-otel-api');
+    expect(sdkFactory.contextKeyCalls, 1,
+        reason: 'OTelAPI must delegate to the newly installed factory');
+
+    // Context must do the same: copyWithValue creates its key through the
+    // factory, which must now be the SDK-installed one, not the cached no-op.
+    Context.current.copyWithValue<String>('via-context', 'value');
+    expect(sdkFactory.contextKeyCalls, 2,
+        reason: 'Context must delegate to the newly installed factory, '
+            'not a no-op factory cached before the SDK initialized');
+  });
+}
+
+/// Stands in for an SDK factory: extends [OTelAPIFactory] (as all SDK
+/// factories do), reports itself as a real implementation, and records
+/// whether Context actually delegates to it.
+class _RecordingFactory extends OTelAPIFactory {
+  int contextKeyCalls = 0;
+
+  _RecordingFactory({
+    required super.apiEndpoint,
+    required super.apiServiceName,
+    required super.apiServiceVersion,
+  });
+
+  @override
+  bool get isAPIFactory => false;
+
+  @override
+  ContextKey<T> contextKey<T>(String name, Uint8List id,
+      {bool isTransferable = false}) {
+    contextKeyCalls++;
+    return super.contextKey<T>(name, id, isTransferable: isTransferable);
+  }
+}

--- a/test/unit/api/context/context_then_initialize_test.dart
+++ b/test/unit/api/context/context_then_initialize_test.dart
@@ -1,0 +1,36 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Companion to context_uninitialized_test.dart (issue #28).
+//
+// Per the OpenTelemetry spec, API use before initialization must work as a
+// no-op — but lazily installing the no-op factory must not then block a
+// later explicit initialization. The lazily-installed factory reports
+// `isAPIFactory == true` precisely so initialization can recognize it as
+// replaceable and upgrade it, rather than throwing "can only be initialized
+// once" at an app that merely touched Context.current too early.
+//
+// This must run before any other test in the process installs a factory, so
+// it lives in its own file — the `test` package runs each test file in its
+// own isolate, giving a pristine (uninitialized) copy of all library statics.
+void main() {
+  test('OTelAPI.initialize() succeeds after pre-init Context access', () {
+    // Spec-permitted early API use: lazily installs the no-op API factory.
+    expect(() => Context.current, returnsNormally);
+    expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+
+    // The auto-installed no-op is replaceable by definition; explicit
+    // initialization must upgrade it, not throw.
+    expect(
+      () => OTelAPI.initialize(
+        endpoint: 'http://localhost:4318',
+        serviceName: 'late-init-service',
+        serviceVersion: '1.0.0',
+      ),
+      returnsNormally,
+    );
+  });
+}

--- a/test/unit/api/context/context_uninitialized_test.dart
+++ b/test/unit/api/context/context_uninitialized_test.dart
@@ -20,13 +20,11 @@ void main() {
     expect(Context.current.baggage, isNull);
   });
 
-  test('Context.root does not throw before OTelAPI.initialize() is called',
-      () {
+  test('Context.root does not throw before OTelAPI.initialize() is called', () {
     expect(() => Context.root, returnsNormally);
   });
 
-  test('Context.current.withBaggage does not throw before initialization',
-      () {
+  test('Context.current.withBaggage does not throw before initialization', () {
     final baggage = OTelAPI.baggageForMap({'key': 'value'});
     expect(() => Context.current.withBaggage(baggage), returnsNormally);
   });

--- a/test/unit/api/context/context_uninitialized_test.dart
+++ b/test/unit/api/context/context_uninitialized_test.dart
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Regression test for https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/28
+//
+// Per the OpenTelemetry spec, the API MUST NOT require explicit
+// initialization: calls made before an SDK/API is installed must operate as
+// no-ops rather than throwing. This must run before any other test in the
+// process calls OTelAPI.initialize(), so it lives in its own file — the
+// `test` package runs each test file in its own isolate, giving a pristine
+// (uninitialized) copy of all library statics.
+void main() {
+  test('Context.current does not throw before OTelAPI.initialize() is called',
+      () {
+    expect(() => Context.current, returnsNormally);
+    expect(Context.current.span, isNull);
+    expect(Context.current.baggage, isNull);
+  });
+
+  test('Context.root does not throw before OTelAPI.initialize() is called',
+      () {
+    expect(() => Context.root, returnsNormally);
+  });
+
+  test('Context.current.withBaggage does not throw before initialization',
+      () {
+    final baggage = OTelAPI.baggageForMap({'key': 'value'});
+    expect(() => Context.current.withBaggage(baggage), returnsNormally);
+  });
+}

--- a/test/unit/api/otel_api_test.dart
+++ b/test/unit/api/otel_api_test.dart
@@ -343,8 +343,30 @@ void main() {
       expect(OTelAPI.meterProviders(), isEmpty);
     });
 
-    test('initialize throws when called twice', () {
-      // Already initialized in setUp, so calling again should throw
+    test('initialize replaces an installed API factory instead of throwing',
+        () {
+      // The API factory is the spec-mandated no-op — whether auto-installed
+      // by early API use or installed by a prior initialize(), it is
+      // replaceable; re-initializing applies the new configuration.
+      expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+      OTelAPI.initialize(
+        endpoint: 'http://localhost:4317',
+        serviceName: 'replacement-service',
+        serviceVersion: '2.0.0',
+      );
+      expect(OTelFactory.otelFactory!.serialize()['apiServiceName'],
+          equals('replacement-service'));
+    });
+
+    test('initialize throws when a real (non-API) factory is installed', () {
+      // A factory that is not the no-op API factory means initialization
+      // already happened (e.g. an SDK installed itself) and must not be
+      // silently discarded.
+      OTelFactory.otelFactory = _FakeSDKFactory(
+        apiEndpoint: 'http://localhost:4317',
+        apiServiceName: 'sdk-service',
+        apiServiceVersion: '1.0.0',
+      );
       expect(() {
         OTelAPI.initialize(
           endpoint: 'http://localhost:4317',
@@ -387,4 +409,18 @@ void main() {
       }, throwsA(isA<ArgumentError>()));
     });
   });
+}
+
+/// Stands in for an SDK factory: extends [OTelAPIFactory] (as all SDK
+/// factories do) and reports itself as a real implementation, so
+/// initialization must refuse to replace it.
+class _FakeSDKFactory extends OTelAPIFactory {
+  _FakeSDKFactory({
+    required super.apiEndpoint,
+    required super.apiServiceName,
+    required super.apiServiceVersion,
+  });
+
+  @override
+  bool get isAPIFactory => false;
 }


### PR DESCRIPTION
## Summary

Carries #29 by @benjaben (rebased onto main, his commit and authorship intact — pushing to the org-fork branch isn't permitted, so this PR supersedes it) plus two follow-up fixes that keep the lazily-installed no-op factory upgradeable.

## Changes

**From #29 (@benjaben):** `Context.root` / `Context.current` threw `StateError('Call initialize() first.')` when accessed before `OTelAPI.initialize()`, violating the OTel spec requirement that the API operate as a no-op without an SDK. They now lazily install the no-op API factory via a single choke point, `OTelFactory.getOrCreateDefault()`, shared with `OTelAPI`. Fixes #28.

**Follow-ups (this PR):**
- `Context` re-reads `OTelFactory.otelFactory` on every access (matching `OTelAPI`) instead of keeping the first factory it saw — otherwise a no-op cached before SDK initialization would shadow the SDK's factory forever, the same staleness class as dartastic_opentelemetry#50.
- `OTelAPI.initialize()` replaces an installed factory when `isAPIFactory` is true instead of throwing — merely touching `Context.current` before initializing no longer permanently blocks explicit initialization. Only a real (non-API) factory still triggers the initialize-once `StateError`. **Behavior change:** re-initializing over a no-op API factory replaces it and applies the new configuration.

Both follow-up defects are pinned by regression tests that were committed failing first (`test: prove lazy no-op install must stay upgradeable`) and turned green by the fix commit:
- `context_then_initialize_test.dart` — pre-init `Context.current` access, then `OTelAPI.initialize()` succeeds.
- `context_factory_upgrade_test.dart` — after a real factory replaces the no-op, `Context` delegates to it (with a built-in control showing `OTelAPI` already did).

## Validation

- `dart analyze` — clean
- `dart format --set-exit-if-changed .` — clean
- `dart test` — 735 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)