### PR TITLE
fix: pre-init OTelAPI accessors lazily install the no-op factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-beta.9-wip]
 
+### Fixed
+- `OTelAPI.instrumentationScope()` recursed into itself when called before
+  initialization, causing an immediate `StackOverflowError`; it now lazily
+  installs the no-op API factory like the other accessors (#27). Thanks
+  @kevmoo.
+- `OTelAPI.tracer()` and `OTelAPI.logger()` threw a null-check error before
+  initialization instead of lazily installing the no-op API factory (#27).
+
 ## [1.0.0-beta.8] - 2026-07-11
 
 ### Added

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -149,17 +149,12 @@ class OTelAPI {
       String version = '1.0.0',
       String? schemaUrl,
       Attributes? attributes}) {
-    return OTelFactory.otelFactory == null
-        ? OTelAPI.instrumentationScope(
-            name: name,
-            version: version,
-            schemaUrl: schemaUrl,
-            attributes: attributes)
-        : OTelFactory.otelFactory!.instrumentationScope(
-            name: name,
-            version: version,
-            schemaUrl: schemaUrl,
-            attributes: attributes);
+    _getAndCacheOtelFactory();
+    return OTelFactory.otelFactory!.instrumentationScope(
+        name: name,
+        version: version,
+        schemaUrl: schemaUrl,
+        attributes: attributes);
   }
 
   /// returns a list of [APITracerProvider]s including the the global default
@@ -270,13 +265,15 @@ class OTelAPI {
 
   /// Get the default or named tracer from the global TracerProvider
   static APITracer tracer(String name) {
+    _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!
         .globalDefaultTracerProvider()
         .getTracer(name);
   }
 
-  /// Get the default or named tracer from the global TracerProvider
+  /// Get the default or named logger from the global LoggerProvider
   static APILogger logger(String name) {
+    _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.globalDefaultLogProvider().getLogger(name);
   }
 

--- a/test/unit/api/otel_api_uninitialized_test.dart
+++ b/test/unit/api/otel_api_uninitialized_test.dart
@@ -1,0 +1,43 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Regression tests for
+// https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/27
+//
+// Per the OpenTelemetry spec, the API MUST NOT require explicit
+// initialization. Before this fix, instrumentationScope() recursed into
+// itself when no factory was installed (immediate StackOverflowError), and
+// tracer()/logger() dereferenced the null global factory instead of lazily
+// installing the no-op.
+//
+// The first test must run before anything else in the process installs a
+// factory, so this lives in its own file — the `test` package runs each test
+// file in its own isolate, giving a pristine (uninitialized) copy of all
+// library statics. Later tests restore that state with OTelAPI.reset().
+void main() {
+  test('instrumentationScope() does not recurse before initialize()', () {
+    expect(OTelFactory.otelFactory, isNull);
+    final scope = OTelAPI.instrumentationScope(name: 'pre-init-scope');
+    expect(scope.name, equals('pre-init-scope'));
+    expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+  });
+
+  test('tracer() lazily installs the no-op factory before initialize()', () {
+    OTelAPI.reset();
+    expect(OTelFactory.otelFactory, isNull);
+    final tracer = OTelAPI.tracer('pre-init-tracer');
+    expect(tracer, isA<APITracer>());
+    expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+  });
+
+  test('logger() lazily installs the no-op factory before initialize()', () {
+    OTelAPI.reset();
+    expect(OTelFactory.otelFactory, isNull);
+    final logger = OTelAPI.logger('pre-init-logger');
+    expect(logger, isA<APILogger>());
+    expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #27, reported by @kevmoo.

Three `OTelAPI` accessors misbehaved when called before initialization, violating the spec requirement that the API work without explicit initialization:

- `instrumentationScope()` recursed into **itself** when no factory was installed — immediate `StackOverflowError`.
- `tracer()` and `logger()` dereferenced the null global factory — null-check error.

All three now call `_getAndCacheOtelFactory()` like the other accessors, lazily installing the spec-mandated no-op API factory (which, since beta.8, reports `isAPIFactory == true` and is upgraded in place by a later explicit initialization).

## Tests

New `test/unit/api/otel_api_uninitialized_test.dart` (own file for a pristine isolate): each accessor is exercised with `OTelFactory.otelFactory == null` and must return a working no-op object and install a factory with `isAPIFactory == true`.

## Validation

- `dart analyze` — clean
- `dart format --set-exit-if-changed .` — clean
- `dart test` — 738 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)