### PR TITLE
fix: complete the pre-init lazy-install lifecycle across the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   @kevmoo.
 - `OTelAPI.tracer()` and `OTelAPI.logger()` threw a null-check error before
   initialization instead of lazily installing the no-op API factory (#27).
+- `TraceState.fromString` / `fromMap` / `empty`, `SpanContext.fromJson`, and
+  `Baggage.fromJson` threw `StateError('Call initialize() first.')` instead
+  of lazily installing the no-op API factory — `fromString` parses the W3C
+  `tracestate` header (a propagator path) and the `fromJson`s run in fresh
+  isolates during deserialization, both classic pre-init calls (#33).
+- `OTelAPI.tracerProviders()` / `meterProviders()` / `loggerProviders()`
+  read OTelAPI's private factory cache instead of the global factory, so
+  providers of a factory installed by an SDK were invisible until some
+  OTelAPI accessor ran (#33).
+- `OTelAPI.attributesFromMap`, `Attributes.of`, and `Map.toAttributes()` no
+  longer bypass the factory via the static `attrsFromMap` "cheat" (obsolete
+  since the beta.8 lazy-install lifecycle); a factory that overrides
+  `attributesFromMap` is now respected on all three paths (#33).
 
 ## [1.0.0-beta.8] - 2026-07-11
 

--- a/lib/src/api/baggage/baggage.dart
+++ b/lib/src/api/baggage/baggage.dart
@@ -94,9 +94,6 @@ class Baggage {
   /// Creates a baggage instance from a JSON representation.
   /// JSON format must be: { key: { value: string, metadata?: string } }
   factory Baggage.fromJson(Map<String, dynamic> json) {
-    // Deserialization often runs in a fresh isolate with pristine statics;
-    // per the OTel spec this lazily installs the no-op API factory rather
-    // than throw.
     final factory = OTelFactory.getOrCreateDefault();
     final entries = <String, BaggageEntry>{};
     for (final entry in json.entries) {

--- a/lib/src/api/baggage/baggage.dart
+++ b/lib/src/api/baggage/baggage.dart
@@ -94,9 +94,10 @@ class Baggage {
   /// Creates a baggage instance from a JSON representation.
   /// JSON format must be: { key: { value: string, metadata?: string } }
   factory Baggage.fromJson(Map<String, dynamic> json) {
-    if (OTelFactory.otelFactory == null) {
-      throw StateError('Call initialize() first.');
-    }
+    // Deserialization often runs in a fresh isolate with pristine statics;
+    // per the OTel spec this lazily installs the no-op API factory rather
+    // than throw.
+    final factory = OTelFactory.getOrCreateDefault();
     final entries = <String, BaggageEntry>{};
     for (final entry in json.entries) {
       if (entry.value is Map) {
@@ -110,13 +111,13 @@ class Baggage {
         if (metadata != null && metadata is! String) {
           continue; // Skip entries with non-string metadata
         }
-        entries[entry.key] = OTelFactory.otelFactory!.baggageEntry(
+        entries[entry.key] = factory.baggageEntry(
           rawValue,
           metadata as String?,
         );
       }
     }
-    return OTelFactory.otelFactory!.baggage(entries);
+    return factory.baggage(entries);
   }
 
   @override

--- a/lib/src/api/common/attributes.dart
+++ b/lib/src/api/common/attributes.dart
@@ -10,8 +10,6 @@ import 'package:meta/meta.dart';
 
 import '../../factory/otel_factory.dart';
 import '../../util/otel_log.dart';
-import '../factory/otel_api_factory.dart';
-import '../otel_api.dart';
 import 'attribute.dart';
 
 part 'attributes_create.dart';
@@ -28,12 +26,10 @@ class Attributes {
   /// @param map The map of key-value pairs to convert to attributes
   /// @return A new Attributes instance containing the converted attributes
   static Attributes of(Map<String, Object> map) {
-    // Directly use the API factory's attrsFromMap if not initialized
-    // This is to allow the creation of attributes for initialization and is
-    // Overrides would take effect after initialization.
-    return OTelFactory.otelFactory != null
-        ? OTelFactory.otelFactory!.attributesFromMap(map)
-        : OTelAPIFactory.attrsFromMap(map);
+    // Attributes are created during initialization (e.g. resource
+    // attributes); per the OTel spec this lazily installs the no-op API
+    // factory rather than throw, and initialize() upgrades it in place.
+    return OTelFactory.getOrCreateDefault().attributesFromMap(map);
   }
 
   /// Creates an Attributes instance from a JSON map.
@@ -334,11 +330,6 @@ extension AttributesExtension on Map<String, Object> {
   /// Convert this map to Attributes
   /// Empty string are not allowed and are skipped
   Attributes toAttributes() {
-    if (OTelFactory.otelFactory == null) {
-      // Cheating here since Attributes is unlikely to be overriden in a
-      // factory and is often called before initialize
-      return OTelAPI.attributesFromMap(this);
-    }
-    return OTelFactory.otelFactory!.attributesFromMap(this);
+    return OTelFactory.getOrCreateDefault().attributesFromMap(this);
   }
 }

--- a/lib/src/api/common/attributes.dart
+++ b/lib/src/api/common/attributes.dart
@@ -26,9 +26,6 @@ class Attributes {
   /// @param map The map of key-value pairs to convert to attributes
   /// @return A new Attributes instance containing the converted attributes
   static Attributes of(Map<String, Object> map) {
-    // Attributes are created during initialization (e.g. resource
-    // attributes); per the OTel spec this lazily installs the no-op API
-    // factory rather than throw, and initialize() upgrades it in place.
     return OTelFactory.getOrCreateDefault().attributesFromMap(map);
   }
 

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -159,27 +159,18 @@ class OTelAPI {
 
   /// returns a list of [APITracerProvider]s including the the global default
   /// and any named providers added.
-  ///
-  /// Reads the global factory — not OTelAPI's cache — so providers of a
-  /// factory installed by an SDK are visible even if no OTelAPI accessor has
-  /// run yet. A list query is a read, so no factory is lazily installed;
-  /// with no factory there are no providers and the list is empty.
   static List<APITracerProvider> tracerProviders() {
     return OTelFactory.otelFactory?.getTracerProviders() ?? [];
   }
 
   /// returns a list of [APIMeterProvider]s including the the global default
   /// and any named providers added.
-  ///
-  /// Reads the global factory — not OTelAPI's cache — like [tracerProviders].
   static List<APIMeterProvider> meterProviders() {
     return OTelFactory.otelFactory?.getMeterProviders() ?? [];
   }
 
   /// returns a list of [APILoggerProvider]s including the global default
   /// and any named providers added.
-  ///
-  /// Reads the global factory — not OTelAPI's cache — like [tracerProviders].
   static List<APILoggerProvider> loggerProviders() {
     return OTelFactory.otelFactory?.getLoggerProviders() ?? [];
   }

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -159,20 +159,29 @@ class OTelAPI {
 
   /// returns a list of [APITracerProvider]s including the the global default
   /// and any named providers added.
+  ///
+  /// Reads the global factory — not OTelAPI's cache — so providers of a
+  /// factory installed by an SDK are visible even if no OTelAPI accessor has
+  /// run yet. A list query is a read, so no factory is lazily installed;
+  /// with no factory there are no providers and the list is empty.
   static List<APITracerProvider> tracerProviders() {
-    return _otelFactory == null ? [] : _otelFactory!.getTracerProviders();
+    return OTelFactory.otelFactory?.getTracerProviders() ?? [];
   }
 
-  /// returns a list of [APITracerProvider]s including the the global default
+  /// returns a list of [APIMeterProvider]s including the the global default
   /// and any named providers added.
+  ///
+  /// Reads the global factory — not OTelAPI's cache — like [tracerProviders].
   static List<APIMeterProvider> meterProviders() {
-    return _otelFactory == null ? [] : _otelFactory!.getMeterProviders();
+    return OTelFactory.otelFactory?.getMeterProviders() ?? [];
   }
 
   /// returns a list of [APILoggerProvider]s including the global default
   /// and any named providers added.
+  ///
+  /// Reads the global factory — not OTelAPI's cache — like [tracerProviders].
   static List<APILoggerProvider> loggerProviders() {
-    return _otelFactory == null ? [] : _otelFactory!.getLoggerProviders();
+    return OTelFactory.otelFactory?.getLoggerProviders() ?? [];
   }
 
   /// Gets a TracerProvider.  If name is null, this returns
@@ -487,9 +496,8 @@ class OTelAPI {
   /// Attributes get added as-is (note - that would be unnecessary code)
   /// Anything else gets converted to an Attribute\<String> via its toString.
   static Attributes attributesFromMap(Map<String, Object> namedMap) {
-    // Cheating a bit since Attributes is unlikley to get overridden
-    // and are often used before initialize() _getAndCacheOtelFactory();
-    return OTelAPIFactory.attrsFromMap(namedMap);
+    _getAndCacheOtelFactory();
+    return OTelFactory.otelFactory!.attributesFromMap(namedMap);
   }
 
   /// Creates attributes from a list of individual attribute objects.

--- a/lib/src/api/trace/span_context.dart
+++ b/lib/src/api/trace/span_context.dart
@@ -127,9 +127,6 @@ class SpanContext {
   /// [json] A map containing the serialized SpanContext properties.
   /// Returns a new SpanContext initialized with the values from the JSON map.
   factory SpanContext.fromJson(Map<String, dynamic> json) {
-    // Deserialization often runs in a fresh isolate with pristine statics;
-    // per the OTel spec this lazily installs the no-op API factory rather
-    // than throw.
     final factory = OTelFactory.getOrCreateDefault();
 
     SpanId? parentSpanId;

--- a/lib/src/api/trace/span_context.dart
+++ b/lib/src/api/trace/span_context.dart
@@ -127,9 +127,10 @@ class SpanContext {
   /// [json] A map containing the serialized SpanContext properties.
   /// Returns a new SpanContext initialized with the values from the JSON map.
   factory SpanContext.fromJson(Map<String, dynamic> json) {
-    if (OTelFactory.otelFactory == null) {
-      throw StateError('Call initialize() first.');
-    }
+    // Deserialization often runs in a fresh isolate with pristine statics;
+    // per the OTel spec this lazily installs the no-op API factory rather
+    // than throw.
+    final factory = OTelFactory.getOrCreateDefault();
 
     SpanId? parentSpanId;
     if (json['parentSpanId'] != null) {
@@ -144,10 +145,9 @@ class SpanContext {
       traceId: OTelAPI.traceIdFrom(json['traceId'] as String),
       spanId: OTelAPI.spanIdFrom(json['spanId'] as String),
       parentSpanId: parentSpanId,
-      traceFlags:
-          OTelFactory.otelFactory!.traceFlags(json['traceFlags'] as int),
-      traceState: OTelFactory.otelFactory!
-          .traceState(json['traceState'] as Map<String, String>? ?? {}),
+      traceFlags: factory.traceFlags(json['traceFlags'] as int),
+      traceState:
+          factory.traceState(json['traceState'] as Map<String, String>? ?? {}),
       isRemote: json['isRemote'] as bool,
     );
   }

--- a/lib/src/api/trace/trace_state.dart
+++ b/lib/src/api/trace/trace_state.dart
@@ -20,10 +20,7 @@ class TraceState {
     _entries = entries ?? {};
   }
 
-  /// Create TraceState from a W3C trace context header string.
-  ///
-  /// Propagators parse `tracestate` headers before initialization; per the
-  /// OTel spec this lazily installs the no-op API factory rather than throw.
+  /// Create TraceState from a W3C trace context header string
   factory TraceState.fromString(String? headerValue) {
     final factory = OTelFactory.getOrCreateDefault();
     if (headerValue == null || headerValue.isEmpty) {

--- a/lib/src/api/trace/trace_state.dart
+++ b/lib/src/api/trace/trace_state.dart
@@ -20,13 +20,14 @@ class TraceState {
     _entries = entries ?? {};
   }
 
-  /// Create TraceState from a W3C trace context header string
+  /// Create TraceState from a W3C trace context header string.
+  ///
+  /// Propagators parse `tracestate` headers before initialization; per the
+  /// OTel spec this lazily installs the no-op API factory rather than throw.
   factory TraceState.fromString(String? headerValue) {
-    if (OTelFactory.otelFactory == null) {
-      throw StateError('Call initialize() first.');
-    }
+    final factory = OTelFactory.getOrCreateDefault();
     if (headerValue == null || headerValue.isEmpty) {
-      return OTelFactory.otelFactory!.traceState({});
+      return factory.traceState({});
     }
 
     final entries = <String, String>{};
@@ -42,23 +43,17 @@ class TraceState {
       }
     }
 
-    return OTelFactory.otelFactory!.traceState(entries);
+    return factory.traceState(entries);
   }
 
   /// Creates a new [TraceState] from a list of key-value pairs.
   factory TraceState.fromMap(Map<String, String> entries) {
-    if (OTelFactory.otelFactory == null) {
-      throw StateError('Call initialize() first.');
-    }
-    return OTelFactory.otelFactory!.traceState(entries);
+    return OTelFactory.getOrCreateDefault().traceState(entries);
   }
 
   /// Creates an empty [TraceState].
   factory TraceState.empty() {
-    if (OTelFactory.otelFactory == null) {
-      throw StateError('Call initialize() first.');
-    }
-    return OTelFactory.otelFactory!.traceState({});
+    return OTelFactory.getOrCreateDefault().traceState({});
   }
 
   /// Returns an unmodifiable view of all key-value entries in this trace state.

--- a/test/unit/api/baggage/baggage_from_json_uninitialized_test.dart
+++ b/test/unit/api/baggage/baggage_from_json_uninitialized_test.dart
@@ -1,0 +1,30 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Regression test for
+// https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/33
+//
+// Deserialization is a classic pre-initialization call — a fresh isolate
+// receiving serialized Baggage has pristine statics — yet Baggage.fromJson
+// threw StateError('Call initialize() first.') instead of lazily installing
+// the no-op API factory per the OTel spec.
+//
+// This must run before anything else in the process installs a factory, so
+// it lives in its own file — the `test` package runs each test file in its
+// own isolate, giving a pristine (uninitialized) copy of all library statics.
+void main() {
+  test('Baggage.fromJson works before initialize()', () {
+    expect(OTelFactory.otelFactory, isNull);
+    final baggage = Baggage.fromJson({
+      'userId': {'value': 'user-1', 'metadata': 'meta'},
+      'region': {'value': 'us-east-1'},
+    });
+    expect(baggage.getEntry('userId')?.value, equals('user-1'));
+    expect(baggage.getEntry('userId')?.metadata, equals('meta'));
+    expect(baggage.getEntry('region')?.value, equals('us-east-1'));
+    expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+  });
+}

--- a/test/unit/api/baggage/baggage_test.dart
+++ b/test/unit/api/baggage/baggage_test.dart
@@ -213,14 +213,17 @@ void main() {
       }, throwsArgumentError);
     });
 
-    test('fromJson throws when OTelFactory not initialized', () {
+    test('fromJson lazily installs the no-op factory when uninitialized', () {
+      // Pre-beta.9 this threw StateError('Call initialize() first.'); per
+      // the OTel spec the API must work without explicit initialization
+      // (#33).
       OTelAPI.reset();
 
-      expect(() {
-        Baggage.fromJson({
-          'key': {'value': 'value'}
-        });
-      }, throwsStateError);
+      final baggage = Baggage.fromJson({
+        'key': {'value': 'value'}
+      });
+      expect(baggage.getEntry('key')?.value, equals('value'));
+      expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
     });
 
     test('copyWith throws when OTelFactory not initialized', () {

--- a/test/unit/api/otel_api_attributes_factory_test.dart
+++ b/test/unit/api/otel_api_attributes_factory_test.dart
@@ -1,0 +1,61 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Regression tests for
+// https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/33
+//
+// OTelAPI.attributesFromMap bypassed the factory unconditionally via the
+// static OTelAPIFactory.attrsFromMap "cheat" — a workaround from when
+// factory access threw before initialize(). Since 1.0.0-beta.8 the factory
+// lazily installs and is upgraded in place, so the cheat is obsolete, and
+// it silently ignored any installed factory that overrides
+// attributesFromMap.
+//
+// The pre-init test must run before anything else in the process installs a
+// factory, so this lives in its own file — the `test` package runs each test
+// file in its own isolate, giving a pristine (uninitialized) copy of all
+// library statics.
+void main() {
+  test('attributesFromMap works before initialize()', () {
+    expect(OTelFactory.otelFactory, isNull);
+    final attributes = OTelAPI.attributesFromMap({'key': 'value', 'num': 42});
+    expect(attributes.getString('key'), equals('value'));
+    expect(attributes.getInt('num'), equals(42));
+  });
+
+  test('attributesFromMap delegates to the installed factory', () {
+    final factory = _CountingFactory(
+      apiEndpoint: 'http://localhost:4318',
+      apiServiceName: 'svc',
+      apiServiceVersion: '1.0.0',
+    );
+    OTelFactory.otelFactory = factory;
+
+    OTelAPI.attributesFromMap({'key': 'value'});
+    expect(factory.attributesFromMapCalls, equals(1),
+        reason: 'attributesFromMap must delegate to the installed factory, '
+            'not bypass it via the static attrsFromMap cheat');
+  });
+}
+
+/// Records whether OTelAPI actually delegates attribute creation to the
+/// installed factory, as an SDK factory overriding attributesFromMap would
+/// expect.
+class _CountingFactory extends OTelAPIFactory {
+  int attributesFromMapCalls = 0;
+
+  _CountingFactory({
+    required super.apiEndpoint,
+    required super.apiServiceName,
+    required super.apiServiceVersion,
+  });
+
+  @override
+  Attributes attributesFromMap(Map<String, Object> namedMap) {
+    attributesFromMapCalls++;
+    return super.attributesFromMap(namedMap);
+  }
+}

--- a/test/unit/api/otel_api_provider_lists_test.dart
+++ b/test/unit/api/otel_api_provider_lists_test.dart
@@ -1,0 +1,50 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Regression tests for
+// https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/33
+//
+// tracerProviders()/meterProviders()/loggerProviders() read OTelAPI's
+// private factory cache instead of the global OTelFactory.otelFactory. When
+// a factory is installed without going through an OTelAPI accessor — an SDK
+// installing itself is the normal case — the cache is still null and the
+// lists come back empty even though the global factory has providers. The
+// lists must reflect the global; the same staleness class was fixed for
+// Context in 1.0.0-beta.8.
+//
+// Pre-init the lists must stay [] WITHOUT installing a factory: a list
+// query is a read, not a use of the API, so it should not force-install.
+//
+// This must run before anything else in the process installs a factory, so
+// it lives in its own file — the `test` package runs each test file in its
+// own isolate, giving a pristine (uninitialized) copy of all library statics.
+void main() {
+  test('provider lists are empty pre-init and do not install a factory', () {
+    expect(OTelAPI.tracerProviders(), isEmpty);
+    expect(OTelAPI.meterProviders(), isEmpty);
+    expect(OTelAPI.loggerProviders(), isEmpty);
+    expect(OTelFactory.otelFactory, isNull);
+  });
+
+  test('provider lists reflect a factory installed without OTelAPI accessors',
+      () {
+    // Simulate an SDK: install the global factory directly, never touching
+    // an OTelAPI accessor that would populate OTelAPI's private cache.
+    final factory = OTelAPIFactory(
+      apiEndpoint: 'http://localhost:4318',
+      apiServiceName: 'sdk-service',
+      apiServiceVersion: '1.0.0',
+    );
+    OTelFactory.otelFactory = factory;
+    final tracerProvider = factory.globalDefaultTracerProvider();
+    final meterProvider = factory.globalDefaultMeterProvider();
+    final loggerProvider = factory.globalDefaultLogProvider();
+
+    expect(OTelAPI.tracerProviders(), contains(tracerProvider));
+    expect(OTelAPI.meterProviders(), contains(meterProvider));
+    expect(OTelAPI.loggerProviders(), contains(loggerProvider));
+  });
+}

--- a/test/unit/api/trace/span_context_from_json_uninitialized_test.dart
+++ b/test/unit/api/trace/span_context_from_json_uninitialized_test.dart
@@ -1,0 +1,33 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Regression test for
+// https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/33
+//
+// Deserialization is a classic pre-initialization call — a fresh isolate
+// receiving a serialized SpanContext has pristine statics — yet
+// SpanContext.fromJson threw StateError('Call initialize() first.') instead
+// of lazily installing the no-op API factory per the OTel spec.
+//
+// This must run before anything else in the process installs a factory, so
+// it lives in its own file — the `test` package runs each test file in its
+// own isolate, giving a pristine (uninitialized) copy of all library statics.
+void main() {
+  test('SpanContext.fromJson works before initialize()', () {
+    expect(OTelFactory.otelFactory, isNull);
+    final spanContext = SpanContext.fromJson({
+      'traceId': '0123456789abcdef0123456789abcdef',
+      'spanId': '0123456789abcdef',
+      'traceFlags': 1,
+      'isRemote': true,
+    });
+    expect(spanContext.traceId.toString(),
+        equals('0123456789abcdef0123456789abcdef'));
+    expect(spanContext.spanId.toString(), equals('0123456789abcdef'));
+    expect(spanContext.isRemote, isTrue);
+    expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+  });
+}

--- a/test/unit/api/trace/trace_state_uninitialized_test.dart
+++ b/test/unit/api/trace/trace_state_uninitialized_test.dart
@@ -1,0 +1,45 @@
+// Licensed under the Apache License, Version 2.0
+// Copyright 2025, Michael Bushe, All rights reserved.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Regression tests for
+// https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/33
+//
+// Per the OpenTelemetry spec, the API MUST NOT require explicit
+// initialization. TraceState.fromString parses the W3C `tracestate` header —
+// exactly what a propagator/extractor does, plausibly before initialize() —
+// yet all three TraceState factory constructors threw
+// StateError('Call initialize() first.') instead of lazily installing the
+// no-op API factory.
+//
+// The first test must run before anything else in the process installs a
+// factory, so this lives in its own file — the `test` package runs each test
+// file in its own isolate, giving a pristine (uninitialized) copy of all
+// library statics. Later tests restore that state with OTelAPI.reset().
+void main() {
+  test('TraceState.fromString works before initialize()', () {
+    expect(OTelFactory.otelFactory, isNull);
+    final traceState = TraceState.fromString('vendor1=value1,vendor2=value2');
+    expect(traceState.get('vendor1'), equals('value1'));
+    expect(traceState.get('vendor2'), equals('value2'));
+    expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+  });
+
+  test('TraceState.fromMap works before initialize()', () {
+    OTelAPI.reset();
+    expect(OTelFactory.otelFactory, isNull);
+    final traceState = TraceState.fromMap({'vendor': 'value'});
+    expect(traceState.get('vendor'), equals('value'));
+    expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+  });
+
+  test('TraceState.empty works before initialize()', () {
+    OTelAPI.reset();
+    expect(OTelFactory.otelFactory, isNull);
+    final traceState = TraceState.empty();
+    expect(traceState.isEmpty, isTrue);
+    expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #33 — the full-API audit follow-up to #27/#28. Built TDD-style: the first commit adds the regression tests red (7 failing against main, with the failure output in the commit history), the second turns them green.

## Changes

**Throw-class** — these threw `StateError('Call initialize() first.')` and now lazily install the no-op factory via `OTelFactory.getOrCreateDefault()` per the spec:
- `TraceState.fromString` / `.fromMap` / `.empty` — `fromString` parses the W3C `tracestate` header, a classic pre-init propagator path.
- `SpanContext.fromJson` and `Baggage.fromJson` — deserialization runs in fresh isolates with pristine statics.

**Stale-cache-class** (same disease fixed for `Context` in beta.8):
- `OTelAPI.tracerProviders()` / `meterProviders()` / `loggerProviders()` now read the global `OTelFactory.otelFactory` instead of OTelAPI's private cache, so an SDK-installed factory's providers are visible even when no OTelAPI accessor has run. Still `[]` with no factory — a list query is a read and does not force-install.

**Cheat removal:**
- `OTelAPI.attributesFromMap`, `Attributes.of`, and `Map.toAttributes()` no longer bypass the factory via static `OTelAPIFactory.attrsFromMap`. The cheat existed because factory access used to throw pre-init; beta.8 removed that premise. `OTelAPI.attributesFromMap` was bypassing **unconditionally**, silently ignoring factories that override `attributesFromMap` — now all three paths respect the installed factory.

One existing test (`baggage_test.dart: fromJson throws when OTelFactory not initialized`) pinned the old throwing contract and was updated to the spec-correct expectation.

## Validation
- TDD - tests were added first and confirmed failed.  Fixes made tests pass
- `dart analyze` — clean
- `dart format --set-exit-if-changed .` — clean
- `dart test` — 747 tests passing (738 baseline + 9 new)
