### PR TITLE
fix: Baggage spec compliance — accept empty values, never throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the API minted random valid IDs and returned recording spans (#40).
   SDK span creation is unaffected: the no-op behavior applies only when
   the installed factory `isAPIFactory`.
+- **`Baggage` now follows the spec for values, names, and no-SDK use.**
+  Per the Baggage API spec, values are any valid UTF-8 string — the empty
+  string is accepted (previously `ArgumentError`) and survives `Set`/`Get`
+  and both `fromJson` paths (previously dropped). Invalid (empty) names are
+  ignored with a warning instead of throwing. `copyWith` / `copyWithout` /
+  `copyWithBaggage` work without an installed SDK (previously `StateError`),
+  per "The Baggage API MUST be fully functional in the absence of an
+  installed SDK."
 
 ## [1.0.0-beta.9] - 2026-07-11
 

--- a/lib/src/api/baggage/baggage.dart
+++ b/lib/src/api/baggage/baggage.dart
@@ -4,6 +4,7 @@
 import 'package:meta/meta.dart';
 
 import '../../factory/otel_factory.dart';
+import '../../util/otel_log.dart';
 import 'baggage_entry.dart';
 
 part 'baggage_create.dart';
@@ -19,22 +20,17 @@ class Baggage {
 
   /// Creates a new baggage instance. The provided entries map is copied
   /// and made immutable to ensure baggage immutability. Defaults to empty.
+  /// Names must be non-empty per spec; entries with empty names are
+  /// ignored and logged. Values may be any valid UTF-8 string, per spec.
   Baggage._([Map<String, BaggageEntry>? entries])
-      : _entries =
-            Map.unmodifiable(Map<String, BaggageEntry>.from(entries ?? {})) {
-    // Validate that no keys are empty strings
-    for (final key in _entries.keys) {
-      if (key.isEmpty) {
-        throw ArgumentError('Baggage keys must not be empty strings');
-      }
-    }
-    // Validate that no values are null
-    for (final entry in _entries.values) {
-      if (entry.value.isEmpty) {
-        throw ArgumentError('Baggage values must not be empty strings');
-      }
-    }
-  }
+      : _entries = Map.unmodifiable(Map<String, BaggageEntry>.fromEntries(
+            (entries ?? {}).entries.where((e) {
+          if (e.key.isEmpty) {
+            OTelLog.warn('Baggage names must be non-empty; entry ignored.');
+            return false;
+          }
+          return true;
+        })));
 
   /// Retrieves a BaggageEntry for the given key, or `null` if not present.
   BaggageEntry? getEntry(String key) => _entries[key];
@@ -56,29 +52,27 @@ class Baggage {
   /// keys that are the same as the keys in [moreBaggage]
   Baggage copyWithBaggage(Baggage moreBaggage) {
     final combined = {..._entries, ...moreBaggage._entries};
-    return OTelFactory.otelFactory!.baggage(combined);
+    return OTelFactory.getOrCreateDefault().baggage(combined);
   }
 
   /// Returns a new Baggage with the given key-value pair added (or replaced).
+  /// Names must be non-empty per spec; an empty name is ignored and logged.
   Baggage copyWith(String key, String value, [String? metadata]) {
-    if (key.isEmpty) throw ArgumentError('Baggage key must not be empty');
-    if (value.isEmpty) throw ArgumentError('Baggage value must not be empty');
-    if (OTelFactory.otelFactory == null) {
-      throw StateError('Call initialize() first.');
+    if (key.isEmpty) {
+      OTelLog.warn('Baggage names must be non-empty; entry ignored.');
+      return this;
     }
+    final factory = OTelFactory.getOrCreateDefault();
     final updated = Map.of(_entries)
-      ..[key] = OTelFactory.otelFactory!.baggageEntry(value, metadata);
-    return OTelFactory.otelFactory!.baggage(updated);
+      ..[key] = factory.baggageEntry(value, metadata);
+    return factory.baggage(updated);
   }
 
   /// Returns a new Baggage with the given key removed (if it exists).
   Baggage copyWithout(String key) {
-    if (OTelFactory.otelFactory == null) {
-      throw StateError('Call initialize() first.');
-    }
     if (!_entries.containsKey(key)) return this;
     final updated = Map.of(_entries)..remove(key);
-    return OTelFactory.otelFactory!.baggage(updated);
+    return OTelFactory.getOrCreateDefault().baggage(updated);
   }
 
   /// Converts the baggage to a JSON representation.
@@ -101,8 +95,8 @@ class Baggage {
         final value = entry.value as Map;
         // Try to get the value field first
         final rawValue = value['value'];
-        if (rawValue is! String || rawValue.isEmpty) {
-          continue; // Skip entries with non-string or empty values
+        if (rawValue is! String) {
+          continue; // Skip entries with non-string values
         }
         final metadata = value['metadata'];
         if (metadata != null && metadata is! String) {

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -430,8 +430,8 @@ class OTelAPI {
       if (entry.value is Map) {
         final value = entry.value as Map;
         final stringValue = value['value'] as String?;
-        if (stringValue == null || stringValue.isEmpty) {
-          continue; // Skip invalid entries
+        if (stringValue == null) {
+          continue; // Skip non-string entries
         }
         entries[entry.key] = OTelFactory.otelFactory!.baggageEntry(
           stringValue,

--- a/test/unit/api/baggage/baggage_spec_compliance_test.dart
+++ b/test/unit/api/baggage/baggage_spec_compliance_test.dart
@@ -1,0 +1,85 @@
+// Licensed under the Apache License, Version 2.0
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Spec-compliance tests for the Baggage API
+// (specification/baggage/api.md):
+//
+// - "Baggage values are any valid UTF-8 strings. Language API MUST accept
+//   any valid UTF-8 string as baggage value in `Set` and return the same
+//   value from `Get`." — the empty string is a valid UTF-8 string.
+// - "Baggage names are any valid, non-empty UTF-8 strings." — an empty name
+//   is invalid, but per error-handling ("API methods MUST NOT throw
+//   unhandled exceptions when used incorrectly by end users") an invalid
+//   name is ignored, not thrown.
+// - "The Baggage API MUST be fully functional in the absence of an
+//   installed SDK."
+void main() {
+  setUp(() {
+    OTelAPI.reset();
+    OTelAPI.initialize(
+      endpoint: 'http://localhost:4318',
+      serviceName: 'test-service',
+      serviceVersion: '1.0.0',
+    );
+  });
+
+  group('Baggage values (any valid UTF-8 string, including empty)', () {
+    test('copyWith accepts an empty value and Get returns it', () {
+      final baggage = OTelAPI.baggage().copyWith('key', '');
+      expect(baggage.getValue('key'), equals(''));
+    });
+
+    test('baggageForMap accepts an empty value', () {
+      final baggage = OTelAPI.baggageForMap({'key': ''});
+      expect(baggage.getValue('key'), equals(''));
+    });
+
+    test('empty values survive a toJson/fromJson round trip', () {
+      final baggage = OTelAPI.baggage().copyWith('key', '');
+      final restored = Baggage.fromJson(baggage.toJson());
+      expect(restored.getValue('key'), equals(''));
+    });
+
+    test('OTelAPI.baggageFromJson accepts an empty value', () {
+      final baggage = OTelAPI.baggageFromJson({
+        'key': {'value': ''}
+      });
+      expect(baggage.getValue('key'), equals(''));
+    });
+  });
+
+  group('Baggage names (invalid names ignored, never thrown)', () {
+    test('copyWith with an empty name returns the baggage unchanged', () {
+      final baggage = OTelAPI.baggage().copyWith('valid', 'v');
+      final result = baggage.copyWith('', 'ignored');
+      expect(result.getAllEntries().keys, equals(['valid']));
+    });
+  });
+
+  group('Baggage is fully functional without an installed SDK', () {
+    test('copyWith works after reset', () {
+      final baggage = OTelAPI.baggage();
+      OTelAPI.reset();
+      final result = baggage.copyWith('key', 'value');
+      expect(result.getValue('key'), equals('value'));
+    });
+
+    test('copyWithout works after reset', () {
+      final baggage = OTelAPI.baggage().copyWith('key', 'value');
+      OTelAPI.reset();
+      final result = baggage.copyWithout('key');
+      expect(result.getEntry('key'), isNull);
+    });
+
+    test('copyWithBaggage works after reset', () {
+      final a = OTelAPI.baggage().copyWith('a', '1');
+      final b = OTelAPI.baggage().copyWith('b', '2');
+      OTelAPI.reset();
+      final merged = a.copyWithBaggage(b);
+      expect(merged.getValue('a'), equals('1'));
+      expect(merged.getValue('b'), equals('2'));
+    });
+  });
+}

--- a/test/unit/api/baggage/baggage_spec_compliance_test.dart
+++ b/test/unit/api/baggage/baggage_spec_compliance_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/baggage/baggage_test.dart
+++ b/test/unit/api/baggage/baggage_test.dart
@@ -145,11 +145,11 @@ void main() {
       final json = {
         'key1': {'value': 'value1', 'metadata': 'metadata1'},
         'key2': {'value': 'value2'},
+        'empty': {'value': '', 'metadata': 'metadata'}, // Valid per spec
         'invalid1': 'not a map',
         'invalid2': {'not-value': 'missing-value-key'},
         'invalid3': {'value': 42}, // Non-string value
-        'invalid4': {'value': '', 'metadata': 'metadata'}, // Empty value
-        'invalid5': {'value': 'value5', 'metadata': 42}, // Non-string metadata
+        'invalid4': {'value': 'value4', 'metadata': 42}, // Non-string metadata
       };
 
       final baggage = Baggage.fromJson(json);
@@ -159,12 +159,14 @@ void main() {
       expect(baggage.getEntry('key2')?.value, equals('value2'));
       expect(baggage.getEntry('key2')?.metadata, isNull);
 
+      // Empty values are valid UTF-8 strings and must be kept
+      expect(baggage.getEntry('empty')?.value, equals(''));
+
       // Invalid entries should be skipped
       expect(baggage.getEntry('invalid1'), isNull);
       expect(baggage.getEntry('invalid2'), isNull);
       expect(baggage.getEntry('invalid3'), isNull);
       expect(baggage.getEntry('invalid4'), isNull);
-      expect(baggage.getEntry('invalid5'), isNull);
     });
 
     test('equals and hashCode work correctly', () {
@@ -199,18 +201,14 @@ void main() {
       expect(baggage.toString(), contains('value1'));
     });
 
-    test('throws when creating with empty key', () {
-      expect(() {
-        final baggage = OTelAPI.baggage();
-        baggage.copyWith('', 'value');
-      }, throwsArgumentError);
+    test('ignores an empty name instead of throwing', () {
+      final baggage = OTelAPI.baggage().copyWith('', 'value');
+      expect(baggage.isEmpty, isTrue);
     });
 
-    test('throws when creating with empty value', () {
-      expect(() {
-        final baggage = OTelAPI.baggage();
-        baggage.copyWith('key', '');
-      }, throwsArgumentError);
+    test('accepts an empty value', () {
+      final baggage = OTelAPI.baggage().copyWith('key', '');
+      expect(baggage.getValue('key'), equals(''));
     });
 
     test('fromJson lazily installs the no-op factory when uninitialized', () {
@@ -226,19 +224,17 @@ void main() {
       expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
     });
 
-    test('copyWith throws when OTelFactory not initialized', () {
+    test('copyWith works when OTelFactory not initialized', () {
       // Create baggage with initialized factory
       final baggage = OTelAPI.baggage();
 
       // Reset to clear factory
       OTelAPI.reset();
 
-      expect(() {
-        baggage.copyWith('key', 'value');
-      }, throwsStateError);
+      expect(baggage.copyWith('key', 'value').getValue('key'), equals('value'));
     });
 
-    test('copyWithout throws when OTelFactory not initialized', () {
+    test('copyWithout works when OTelFactory not initialized', () {
       // Create baggage with initialized factory
       final entry = OTelAPI.baggageEntry('value', 'metadata');
       final baggage = OTelAPI.baggage({'key': entry});
@@ -246,9 +242,7 @@ void main() {
       // Reset to clear factory
       OTelAPI.reset();
 
-      expect(() {
-        baggage.copyWithout('key');
-      }, throwsStateError);
+      expect(baggage.copyWithout('key').getEntry('key'), isNull);
     });
 
     test('baggage creation and manipulation', () {


### PR DESCRIPTION
## Summary

Documents and fixes a spec violation found auditing against `specification/baggage/api.md` and `error-handling.md`. TDD: first commit pins the spec contracts red (8 failing), second turns them green.

## The violation

- "Baggage **values** are any valid UTF-8 strings. Language API MUST accept any valid UTF-8 string as baggage **value** in `Set` and return the same value from `Get`." — the empty string is a valid UTF-8 string, but `Baggage` threw `ArgumentError` on it, and both `fromJson` paths silently dropped empty values.
- "API methods MUST NOT throw unhandled exceptions when used incorrectly by end users" (error-handling.md) — empty names threw `ArgumentError`; now ignored with a warning (names must be non-empty per spec, so the entry is invalid — but rejection is a log, not a crash).
- "The Baggage API MUST be fully functional in the absence of an installed SDK." — `copyWith`/`copyWithout`/`copyWithBaggage` threw `StateError('Call initialize() first.')` after reset; they now lazily install the no-op factory like the rest of the API.

## Merge order

Stacked on #35 (which stacks on #34): merge #34 → #35 → this.

## Validation

- `dart analyze` / `dart format --set-exit-if-changed .` — clean
- `dart test` — 755 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)