### PR TITLE
fix: validate tracestate tenant/system keys per W3C grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer bypass the factory via the static `attrsFromMap` "cheat" (obsolete
   since the beta.8 lazy-install lifecycle); a factory that overrides
   `attributesFromMap` is now respected on all three paths (#33).
+- `TraceState` multi-tenant `tracestate` keys (`tenant-id@system-id`) now
+  match the W3C Trace Context key grammar: a `tenant-id` may start with a
+  digit, and `tenant-id`/`system-id` are length-capped (241/14 chars).
+  Previously a digit-leading tenant was rejected and over-long ids
+  accepted (#38).
 
 ## [1.0.0-beta.8] - 2026-07-11
 

--- a/lib/src/api/trace/trace_state.dart
+++ b/lib/src/api/trace/trace_state.dart
@@ -8,8 +8,10 @@ part 'trace_state_create.dart';
 /// TraceState follows the W3C Trace Context specification.
 class TraceState {
   static const int _maxKeyValuePairs = 32;
-  // Allow tenant format with @ character (tenant@vendor)
-  static final RegExp _keyFormat = RegExp(r'^[a-z][a-z0-9_\-*/]*$');
+  static final RegExp _simpleKeyFormat = RegExp(r'^[a-z][a-z0-9_\-*/]{0,255}$');
+  static final RegExp _tenantIdFormat =
+      RegExp(r'^[a-z0-9][a-z0-9_\-*/]{0,240}$');
+  static final RegExp _systemIdFormat = RegExp(r'^[a-z][a-z0-9_\-*/]{0,13}$');
   static final RegExp _valueFormat = RegExp(
       r'^[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]$');
 
@@ -117,32 +119,18 @@ class TraceState {
     return _entries.entries.map((e) => '${e.key}=${e.value}').join(',');
   }
 
-  /// Validate key format, with explicit support for tenant format (tenant@vendor)
+  /// Validate a tracestate key: a simple key, or a multi-tenant
+  /// `tenant-id@system-id` key.
   static bool _isValidKey(String key) {
-    // If the key contains @, handle it as a tenant format key
-    if (key.contains('@')) {
-      // Tenant format can only have one @ symbol
-      if (key.indexOf('@') != key.lastIndexOf('@')) {
-        return false;
-      }
-
-      // Split the key into tenant and vendor parts
-      final parts = key.split('@');
-      if (parts.length != 2) return false;
-
-      // Validate each part separately
-      final tenant = parts[0];
-      final vendor = parts[1];
-
-      // Tenant and vendor must be lowercase letters or digits,
-      // and start with a lowercase letter
-      final simpleKeyFormat = RegExp(r'^[a-z][a-z0-9_\-*/]*$');
-      return simpleKeyFormat.hasMatch(tenant) &&
-          simpleKeyFormat.hasMatch(vendor);
+    final atIndex = key.indexOf('@');
+    if (atIndex != -1) {
+      if (atIndex != key.lastIndexOf('@')) return false;
+      final tenant = key.substring(0, atIndex);
+      final system = key.substring(atIndex + 1);
+      return _tenantIdFormat.hasMatch(tenant) &&
+          _systemIdFormat.hasMatch(system);
     }
-
-    // Non-tenant keys use the standard format
-    return _keyFormat.hasMatch(key);
+    return _simpleKeyFormat.hasMatch(key);
   }
 
   /// Validate value format

--- a/test/unit/api/trace/trace_state_test.dart
+++ b/test/unit/api/trace/trace_state_test.dart
@@ -163,6 +163,40 @@ void main() {
       expect(traceState.get('tenant@vendor'), equals('value'));
     });
 
+    test('put accepts a tenant id that starts with a digit', () {
+      // W3C tenant-id = ( lcalpha / DIGIT ) ...
+      final state = OTelAPI.traceState({}).put('9legacy@acme', 'v');
+      expect(state.get('9legacy@acme'), equals('v'));
+    });
+
+    test('fromString keeps a digit-leading multi-tenant key', () {
+      final state = TraceState.fromString('9legacy@acme=v');
+      expect(state.get('9legacy@acme'), equals('v'));
+    });
+
+    test('put accepts boundary-length tenant and system ids', () {
+      final key =
+          '${'a' * 241}@${'a' * 14}'; // tenant-id max 241, system-id max 14
+      final state = OTelAPI.traceState({}).put(key, 'v');
+      expect(state.get(key), equals('v'));
+    });
+
+    test('put rejects a tenant id longer than 241 chars', () {
+      expect(() => OTelAPI.traceState({}).put('${'a' * 242}@acme', 'v'),
+          throwsArgumentError);
+    });
+
+    test('put rejects a system id longer than 14 chars', () {
+      expect(() => OTelAPI.traceState({}).put('acme@${'a' * 15}', 'v'),
+          throwsArgumentError);
+    });
+
+    test('put rejects a system id that starts with a digit', () {
+      // W3C system-id = lcalpha ...
+      expect(() => OTelAPI.traceState({}).put('acme@9vendor', 'v'),
+          throwsArgumentError);
+    });
+
     test('maintains immutability', () {
       final traceState = OTelAPI.traceState({'key': 'value'});
       final updatedState = traceState.put('newkey', 'newvalue');


### PR DESCRIPTION
## Summary

The multi-tenant `tracestate` key branch of `TraceState._isValidKey` diverged from the [W3C Trace Context key grammar](https://www.w3.org/TR/trace-context/#key) in two ways:

- **tenant-id** was required to start with a lowercase letter, but W3C allows a leading digit (`tenant-id = ( lcalpha / DIGIT ) ...`) — so a valid key like `9legacy@acme` was wrongly rejected.
- **No length bounds** — W3C caps `tenant-id` at 241 chars and `system-id` at 14; over-long ids were silently accepted.

The fix replaces the shared per-part regex with distinct `_tenantIdFormat` / `_systemIdFormat` patterns, and also caps the simple-key regex at 256 chars to match the spec.

## Validation

- 4 red tests pin the contracts (committed first, failing against the old regex); the fix turns them green.
- `dart analyze` — clean
- `dart format` — clean
- `dart test` — 753 passing (was 747)

🤖 Generated with [Claude Code](https://claude.com/claude-code)