### PR TITLE
test: document no-SDK span behavior spec violations (#40)

### DIFF
--- a/test/unit/api/trace/no_sdk_span_behavior_test.dart
+++ b/test/unit/api/trace/no_sdk_span_behavior_test.dart
@@ -1,0 +1,56 @@
+// Licensed under the Apache License, Version 2.0
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+// Spec-compliance tests for trace/api.md, "Behavior of the API in the
+// absence of an installed SDK":
+//
+// - "The API MUST return a non-recording Span with the SpanContext in the
+//   parent Context (whether explicitly given or implicit current)."
+// - "If the parent Context contains no Span, an empty non-recording Span
+//   MUST be returned instead (i.e., having a SpanContext with all-zero
+//   Span and Trace IDs, empty Tracestate, and unsampled TraceFlags)."
+//
+// These run with only the API initialized — no SDK — which is exactly the
+// mode the quoted section governs.
+void main() {
+  setUp(() {
+    OTelAPI.reset();
+    OTelAPI.initialize(
+      endpoint: 'http://localhost:4318',
+      serviceName: 'test-service',
+      serviceVersion: '1.0.0',
+    );
+  });
+
+  group('no-SDK span behavior (trace/api.md)', () {
+    test('parentless span has all-zero IDs and unsampled flags', () {
+      final span =
+          OTelAPI.tracerProvider().getTracer('test').startSpan('root');
+      expect(span.spanContext.isValid, isFalse);
+      expect(span.spanContext.traceFlags.isSampled, isFalse);
+    });
+
+    test('span is non-recording', () {
+      final span =
+          OTelAPI.tracerProvider().getTracer('test').startSpan('root');
+      expect(span.isRecording, isFalse);
+    });
+
+    test('span with a parent carries the parent SpanContext unchanged', () {
+      final parent = OTelAPI.spanContext(
+        traceId: OTelAPI.traceIdFrom('0123456789abcdef0123456789abcdef'),
+        spanId: OTelAPI.spanIdFrom('0123456789abcdef'),
+        isRemote: true,
+      );
+      final context = OTelAPI.context().withSpanContext(parent);
+      final span = OTelAPI
+          .tracerProvider()
+          .getTracer('test')
+          .startSpan('child', context: context);
+      expect(span.spanContext.traceId, equals(parent.traceId));
+      expect(span.spanContext.spanId, equals(parent.spanId));
+    });
+  });
+}

--- a/test/unit/api/trace/no_sdk_span_behavior_test.dart
+++ b/test/unit/api/trace/no_sdk_span_behavior_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
@@ -24,17 +25,17 @@ void main() {
     );
   });
 
-  group('no-SDK span behavior (trace/api.md)', () {
+  group('no-SDK span behavior (trace/api.md)',
+      skip: 'Known spec violation — fix needs a design decision because the '
+          'SDK delegates span creation to APITracer; see #40', () {
     test('parentless span has all-zero IDs and unsampled flags', () {
-      final span =
-          OTelAPI.tracerProvider().getTracer('test').startSpan('root');
+      final span = OTelAPI.tracerProvider().getTracer('test').startSpan('root');
       expect(span.spanContext.isValid, isFalse);
       expect(span.spanContext.traceFlags.isSampled, isFalse);
     });
 
     test('span is non-recording', () {
-      final span =
-          OTelAPI.tracerProvider().getTracer('test').startSpan('root');
+      final span = OTelAPI.tracerProvider().getTracer('test').startSpan('root');
       expect(span.isRecording, isFalse);
     });
 
@@ -45,8 +46,7 @@ void main() {
         isRemote: true,
       );
       final context = OTelAPI.context().withSpanContext(parent);
-      final span = OTelAPI
-          .tracerProvider()
+      final span = OTelAPI.tracerProvider()
           .getTracer('test')
           .startSpan('child', context: context);
       expect(span.spanContext.traceId, equals(parent.traceId));


### PR DESCRIPTION
## Summary

Documents (does not fix) the spec violations in #40, found auditing against `specification/trace/api.md`, "Behavior of the API in the absence of an installed SDK". TDD: the first commit pins the contracts red (3 failing, with the observed wrong values in the test output), the second skips them pointing at #40 so CI stays green until the fix lands.

## The violations (API-only, no SDK)

- Parentless spans get random valid trace/span IDs — the spec requires "a `SpanContext` with all-zero Span and Trace IDs, empty Tracestate, and unsampled TraceFlags".
- Spans report `isRecording == true` — the spec requires non-recording spans.
- A span with a parent gets a freshly minted span ID — the spec requires "a non-recording `Span` with the `SpanContext` in the parent `Context`" unchanged.

## Why not fixed here

The SDK's `Tracer` delegates `createSpan`/`startSpan` to `APITracer` as its ID-generation engine, so making the API no-op unconditionally would break real SDK spans. The fix needs a design decision (condition on `isAPIFactory`, or restructure the delegation and add `NonRecordingSpan`) — see #40. Removing the `skip:` in `test/unit/api/trace/no_sdk_span_behavior_test.dart` reproduces all three.

## Validation

- `dart analyze` / `dart test` — clean (3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)