### PR TITLE
test: document missing global propagator API (#42)

### DIFF
--- a/test/unit/api/context/propagation/global_propagator_test.dart
+++ b/test/unit/api/context/propagation/global_propagator_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:test/test.dart';
 
@@ -10,7 +11,8 @@ import 'package:test/test.dart';
 //   configured otherwise."
 void main() {
   test('the API provides a global TextMapPropagator with a no-op default',
-      () {
+      skip: 'Not implemented; needs a design decision on generic vs '
+          'non-generic global surface — see #42', () {
     fail('No global propagator accessor or no-op TextMapPropagator exists '
         'in the API; instrumentation libraries cannot obtain "the" '
         'propagator as the spec requires.');

--- a/test/unit/api/context/propagation/global_propagator_test.dart
+++ b/test/unit/api/context/propagation/global_propagator_test.dart
@@ -1,0 +1,18 @@
+// Licensed under the Apache License, Version 2.0
+
+import 'package:test/test.dart';
+
+// Spec-compliance test for context/api-propagators.md, "Global Propagators":
+//
+// - "The OpenTelemetry API MUST provide a way to obtain a propagator for
+//   each supported Propagator type" — with Get/Set global methods.
+// - "The OpenTelemetry API MUST use no-op propagators unless explicitly
+//   configured otherwise."
+void main() {
+  test('the API provides a global TextMapPropagator with a no-op default',
+      () {
+    fail('No global propagator accessor or no-op TextMapPropagator exists '
+        'in the API; instrumentation libraries cannot obtain "the" '
+        'propagator as the spec requires.');
+  });
+}


### PR DESCRIPTION
## Summary

Documents (does not fix) the spec violation in #42, found auditing against `specification/context/api-propagators.md`, "Global Propagators". TDD: first commit pins the requirement red, second skips it pointing at #42 so CI stays green until the design lands.

## The violation

- "The OpenTelemetry API MUST provide a way to obtain a propagator for each supported `Propagator` type" with global Get/Set, and "MUST use no-op propagators unless explicitly configured otherwise" — neither a global accessor nor a no-op `TextMapPropagator` exists; instrumentation libraries cannot obtain "the" propagator.

## Why not fixed here

The existing `TextMapPropagator<C, V>` is generic, so a global holder is type-lossy; whether the global surface should be non-generic (as in other OTel languages) is a design decision — see #42.

## Validation

- `dart analyze` / `dart test` — clean (1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)