### PR TITLE
chore: CODEOWNERS — maintainer review required on every PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Maintainer review is required on every PR.
+* @michaelbushe


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @michaelbushe`. Combined with the now-enabled "require code owner reviews" branch protection, every PR needs @michaelbushe's review before merge, while the new write-access collaborators' approvals satisfy the general review count and they can push feature branches directly to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)