### PR TITLE
chore: CNCF headers — Copyright The OpenTelemetry Authors + SPDX

### DIFF
--- a/example/dartastic_opentelemetry_api_example.dart
+++ b/example/dartastic_opentelemetry_api_example.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 

--- a/example/web/web_example.dart
+++ b/example/web/web_example.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:js_interop';
 

--- a/lib/dartastic_opentelemetry_api.dart
+++ b/lib/dartastic_opentelemetry_api.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// OpenTelemetry API for Dart
 ///

--- a/lib/src/api/baggage/baggage.dart
+++ b/lib/src/api/baggage/baggage.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
 

--- a/lib/src/api/baggage/baggage_create.dart
+++ b/lib/src/api/baggage/baggage_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'baggage.dart';
 

--- a/lib/src/api/baggage/baggage_entry.dart
+++ b/lib/src/api/baggage/baggage_entry.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
 

--- a/lib/src/api/baggage/baggage_entry_create.dart
+++ b/lib/src/api/baggage/baggage_entry_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'baggage_entry.dart';
 

--- a/lib/src/api/common/attribute.dart
+++ b/lib/src/api/common/attribute.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';

--- a/lib/src/api/common/attribute_create.dart
+++ b/lib/src/api/common/attribute_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'attribute.dart';
 

--- a/lib/src/api/common/attributes.dart
+++ b/lib/src/api/common/attributes.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 library;
 

--- a/lib/src/api/common/attributes_create.dart
+++ b/lib/src/api/common/attributes_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'attributes.dart';
 

--- a/lib/src/api/common/instrumentation_scope.dart
+++ b/lib/src/api/common/instrumentation_scope.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 library;
 

--- a/lib/src/api/common/instrumentation_scope_create.dart
+++ b/lib/src/api/common/instrumentation_scope_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'instrumentation_scope.dart';
 

--- a/lib/src/api/common/signal_instance_key.dart
+++ b/lib/src/api/common/signal_instance_key.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 import 'attributes.dart';
 
 enum Signal { traces, metrics, logs }

--- a/lib/src/api/common/timestamp.dart
+++ b/lib/src/api/common/timestamp.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:fixnum/fixnum.dart';
 import 'package:meta/meta.dart';

--- a/lib/src/api/context/context.dart
+++ b/lib/src/api/context/context.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 import 'dart:convert';

--- a/lib/src/api/context/context_create.dart
+++ b/lib/src/api/context/context_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'context.dart';
 

--- a/lib/src/api/context/context_key.dart
+++ b/lib/src/api/context/context_key.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:typed_data';
 import '../id/id_generator.dart';

--- a/lib/src/api/context/context_key_create.dart
+++ b/lib/src/api/context/context_key_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'context_key.dart';
 

--- a/lib/src/api/context/isolate_support.dart
+++ b/lib/src/api/context/isolate_support.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:isolate';
 

--- a/lib/src/api/context/isolate_support_web.dart
+++ b/lib/src/api/context/isolate_support_web.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Web platform implementation - no dart:isolate
 

--- a/lib/src/api/context/propagation/composite_propagator.dart
+++ b/lib/src/api/context/propagation/composite_propagator.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../context.dart';
 import 'text_map_propagator.dart';

--- a/lib/src/api/context/propagation/context_propagator.dart
+++ b/lib/src/api/context/propagation/context_propagator.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
 

--- a/lib/src/api/context/propagation/text_map_propagator.dart
+++ b/lib/src/api/context/propagation/text_map_propagator.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../context.dart';
 

--- a/lib/src/api/factory/otel_api_factory.dart
+++ b/lib/src/api/factory/otel_api_factory.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:typed_data';
 

--- a/lib/src/api/id/id_generator.dart
+++ b/lib/src/api/id/id_generator.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:math';
 import 'dart:typed_data';

--- a/lib/src/api/logs/log_record.dart
+++ b/lib/src/api/logs/log_record.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 import 'package:fixnum/fixnum.dart';
 
 import '../common/attributes.dart';

--- a/lib/src/api/logs/logger.dart
+++ b/lib/src/api/logs/logger.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 import '../common/attributes.dart';
 import '../context/context.dart';
 import 'severity.dart';

--- a/lib/src/api/logs/logger_create.dart
+++ b/lib/src/api/logs/logger_create.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 part of 'logger.dart';
 
 class LoggerCreate {

--- a/lib/src/api/logs/logger_provider.dart
+++ b/lib/src/api/logs/logger_provider.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 // ignore_for_file: unnecessary_getters_setters
 
 import '../../util/otel_log.dart';

--- a/lib/src/api/logs/logger_provider_create.dart
+++ b/lib/src/api/logs/logger_provider_create.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 part of 'logger_provider.dart';
 
 class LogProviderCreate {

--- a/lib/src/api/logs/severity.dart
+++ b/lib/src/api/logs/severity.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 enum Severity {
   UNSPECIFIED(0, SeverityLevel.UNSPECIFIED),
   TRACE(1, SeverityLevel.TRACE),

--- a/lib/src/api/metrics/counter.dart
+++ b/lib/src/api/metrics/counter.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../common/attributes.dart';
 import 'meter.dart';

--- a/lib/src/api/metrics/counter_create.dart
+++ b/lib/src/api/metrics/counter_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'counter.dart';
 

--- a/lib/src/api/metrics/gauge.dart
+++ b/lib/src/api/metrics/gauge.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../common/attributes.dart';
 import 'meter.dart';

--- a/lib/src/api/metrics/gauge_create.dart
+++ b/lib/src/api/metrics/gauge_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'gauge.dart';
 

--- a/lib/src/api/metrics/histogram.dart
+++ b/lib/src/api/metrics/histogram.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../common/attributes.dart';
 import 'meter.dart';

--- a/lib/src/api/metrics/histogram_create.dart
+++ b/lib/src/api/metrics/histogram_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'histogram.dart';
 

--- a/lib/src/api/metrics/instrument.dart
+++ b/lib/src/api/metrics/instrument.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'meter.dart';
 

--- a/lib/src/api/metrics/measurement.dart
+++ b/lib/src/api/metrics/measurement.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../common/attributes.dart';
 

--- a/lib/src/api/metrics/measurement_create.dart
+++ b/lib/src/api/metrics/measurement_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'measurement.dart';
 

--- a/lib/src/api/metrics/meter.dart
+++ b/lib/src/api/metrics/meter.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../common/attributes.dart';
 import '../otel_api.dart';

--- a/lib/src/api/metrics/meter_create.dart
+++ b/lib/src/api/metrics/meter_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'meter.dart';
 

--- a/lib/src/api/metrics/meter_provider.dart
+++ b/lib/src/api/metrics/meter_provider.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // ignore_for_file: unnecessary_getters_setters
 

--- a/lib/src/api/metrics/meter_provider_create.dart
+++ b/lib/src/api/metrics/meter_provider_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'meter_provider.dart';
 

--- a/lib/src/api/metrics/metric_point.dart
+++ b/lib/src/api/metrics/metric_point.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../common/attributes.dart';
 

--- a/lib/src/api/metrics/observable_callback.dart
+++ b/lib/src/api/metrics/observable_callback.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'observable_result.dart';
 

--- a/lib/src/api/metrics/observable_counter.dart
+++ b/lib/src/api/metrics/observable_counter.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'measurement.dart';
 import 'meter.dart';

--- a/lib/src/api/metrics/observable_counter_create.dart
+++ b/lib/src/api/metrics/observable_counter_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'observable_counter.dart';
 

--- a/lib/src/api/metrics/observable_gauge.dart
+++ b/lib/src/api/metrics/observable_gauge.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'measurement.dart';
 import 'meter.dart';

--- a/lib/src/api/metrics/observable_gauge_create.dart
+++ b/lib/src/api/metrics/observable_gauge_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'observable_gauge.dart';
 

--- a/lib/src/api/metrics/observable_result.dart
+++ b/lib/src/api/metrics/observable_result.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../factory/otel_factory.dart';
 import '../common/attributes.dart';

--- a/lib/src/api/metrics/observable_up_down_counter.dart
+++ b/lib/src/api/metrics/observable_up_down_counter.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'measurement.dart';
 import 'meter.dart';

--- a/lib/src/api/metrics/observable_up_down_counter_create.dart
+++ b/lib/src/api/metrics/observable_up_down_counter_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'observable_up_down_counter.dart';
 

--- a/lib/src/api/metrics/up_down_counter.dart
+++ b/lib/src/api/metrics/up_down_counter.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../common/attributes.dart';
 import 'meter.dart';

--- a/lib/src/api/metrics/up_down_counter_create.dart
+++ b/lib/src/api/metrics/up_down_counter_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'up_down_counter.dart';
 

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:typed_data';
 

--- a/lib/src/api/semantics/gen_ai_semantics.dart
+++ b/lib/src/api/semantics/gen_ai_semantics.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 // Copyright 2025, Mindful Software LLC, All rights reserved.
 
 import 'semantics.dart';

--- a/lib/src/api/semantics/lifecycle_state.dart
+++ b/lib/src/api/semantics/lifecycle_state.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Application lifecycle states
 enum LifecycleState {

--- a/lib/src/api/semantics/navigation_action.dart
+++ b/lib/src/api/semantics/navigation_action.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Navigation actions in a UI context
 enum NavigationAction {

--- a/lib/src/api/semantics/semantic_events.dart
+++ b/lib/src/api/semantics/semantic_events.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// OpenTelemetry semantic-convention event names.
 ///

--- a/lib/src/api/semantics/semantic_metrics.dart
+++ b/lib/src/api/semantics/semantic_metrics.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// OpenTelemetry semantic-convention metric instrument names.
 ///

--- a/lib/src/api/semantics/semantic_values.dart
+++ b/lib/src/api/semantics/semantic_values.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// OpenTelemetry Semantic Conventions — typed value enums.
 ///

--- a/lib/src/api/semantics/semantics.dart
+++ b/lib/src/api/semantics/semantics.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// OpenTelemetry semantic-convention attribute key enums.
 ///

--- a/lib/src/api/semantics/ui_semantics.dart
+++ b/lib/src/api/semantics/ui_semantics.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'semantics.dart';
 

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
 

--- a/lib/src/api/trace/span_context.dart
+++ b/lib/src/api/trace/span_context.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../factory/otel_factory.dart';
 import '../otel_api.dart';

--- a/lib/src/api/trace/span_context_create.dart
+++ b/lib/src/api/trace/span_context_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'span_context.dart';
 

--- a/lib/src/api/trace/span_create.dart
+++ b/lib/src/api/trace/span_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'span.dart';
 

--- a/lib/src/api/trace/span_event.dart
+++ b/lib/src/api/trace/span_event.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
 

--- a/lib/src/api/trace/span_event_create.dart
+++ b/lib/src/api/trace/span_event_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'span_event.dart';
 

--- a/lib/src/api/trace/span_id.dart
+++ b/lib/src/api/trace/span_id.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:typed_data';
 import '../id/id_generator.dart';

--- a/lib/src/api/trace/span_id_create.dart
+++ b/lib/src/api/trace/span_id_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'span_id.dart';
 

--- a/lib/src/api/trace/span_kind.dart
+++ b/lib/src/api/trace/span_kind.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Type of span. Can be used to specify additional relationships between spans
 /// in addition to a parent/child relationship.

--- a/lib/src/api/trace/span_link.dart
+++ b/lib/src/api/trace/span_link.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
 

--- a/lib/src/api/trace/span_link_create.dart
+++ b/lib/src/api/trace/span_link_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'span_link.dart';
 

--- a/lib/src/api/trace/trace_flags.dart
+++ b/lib/src/api/trace/trace_flags.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'span_context.dart' show SpanContext;
 

--- a/lib/src/api/trace/trace_flags_create.dart
+++ b/lib/src/api/trace/trace_flags_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'trace_flags.dart';
 

--- a/lib/src/api/trace/trace_id.dart
+++ b/lib/src/api/trace/trace_id.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:typed_data';
 

--- a/lib/src/api/trace/trace_id_create.dart
+++ b/lib/src/api/trace/trace_id_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'trace_id.dart';
 

--- a/lib/src/api/trace/trace_state.dart
+++ b/lib/src/api/trace/trace_state.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../factory/otel_factory.dart';
 

--- a/lib/src/api/trace/trace_state_create.dart
+++ b/lib/src/api/trace/trace_state_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'trace_state.dart';
 

--- a/lib/src/api/trace/tracer.dart
+++ b/lib/src/api/trace/tracer.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import '../../factory/otel_factory.dart';
 import '../../util/default_time_provider.dart';

--- a/lib/src/api/trace/tracer_create.dart
+++ b/lib/src/api/trace/tracer_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'tracer.dart';
 

--- a/lib/src/api/trace/tracer_provider.dart
+++ b/lib/src/api/trace/tracer_provider.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // ignore_for_file: unnecessary_getters_setters
 

--- a/lib/src/api/trace/tracer_provider_create.dart
+++ b/lib/src/api/trace/tracer_provider_create.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 part of 'tracer_provider.dart';
 

--- a/lib/src/factory/otel_factory.dart
+++ b/lib/src/factory/otel_factory.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:typed_data';
 

--- a/lib/src/util/default_time_provider.dart
+++ b/lib/src/util/default_time_provider.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Conditional facade for the platform-default `TimeProvider`. Native
 // targets get `SystemTimeProvider` (DateTime.now); web targets (JS or Wasm)

--- a/lib/src/util/default_time_provider_io.dart
+++ b/lib/src/util/default_time_provider_io.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'time_provider.dart';
 

--- a/lib/src/util/default_time_provider_web.dart
+++ b/lib/src/util/default_time_provider_web.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'time_provider.dart';
 import 'web_time_provider.dart';

--- a/lib/src/util/otel_log.dart
+++ b/lib/src/util/otel_log.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// The log levels supported by OTelLog.
 ///

--- a/lib/src/util/time.dart
+++ b/lib/src/util/time.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 // Helper function for getting current time in OTel nano format with microsecond precision
 import 'package:fixnum/fixnum.dart';
 

--- a/lib/src/util/time_provider.dart
+++ b/lib/src/util/time_provider.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// A clock for span start, end, and event timestamps.
 ///

--- a/lib/src/util/web_time_provider.dart
+++ b/lib/src/util/web_time_provider.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Conditional facade for `WebTimeProvider`. On web targets (Dart-on-JS or
 // Wasm) this exports an implementation backed by `window.performance.now()`

--- a/lib/src/util/web_time_provider_stub.dart
+++ b/lib/src/util/web_time_provider_stub.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'time_provider.dart';
 

--- a/lib/src/util/web_time_provider_web.dart
+++ b/lib/src/util/web_time_provider_web.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:web/web.dart' as web;
 

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:test/expect.dart';
 

--- a/test/unit/api/baggage/baggage_entry_test.dart
+++ b/test/unit/api/baggage/baggage_entry_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/src/api/otel_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/baggage/baggage_from_json_uninitialized_test.dart
+++ b/test/unit/api/baggage/baggage_from_json_uninitialized_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/baggage/baggage_test.dart
+++ b/test/unit/api/baggage/baggage_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // ignore_for_file: avoid_dynamic_calls
 

--- a/test/unit/api/common/attribute_test.dart
+++ b/test/unit/api/common/attribute_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/src/api/otel_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/common/attributes_test.dart
+++ b/test/unit/api/common/attributes_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/common/test_instrumentation_scope.dart
+++ b/test/unit/api/common/test_instrumentation_scope.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 // Test file to verify InstrumentationScopeCreate is accessible
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/common/timestamp_test.dart
+++ b/test/unit/api/common/timestamp_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/src/api/common/timestamp.dart';
 import 'package:fixnum/fixnum.dart';

--- a/test/unit/api/context/advanced_context_key_test.dart
+++ b/test/unit/api/context/advanced_context_key_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/src/api/otel_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/context/clear_current_span_test.dart
+++ b/test/unit/api/context/clear_current_span_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/context/context_coverage_test.dart
+++ b/test/unit/api/context/context_coverage_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/context/context_exception_test.dart
+++ b/test/unit/api/context/context_exception_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/test/unit/api/context/context_factory_upgrade_test.dart
+++ b/test/unit/api/context/context_factory_upgrade_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:typed_data';
 

--- a/test/unit/api/context/context_key_test.dart
+++ b/test/unit/api/context/context_key_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/context/context_test.dart
+++ b/test/unit/api/context/context_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/context/context_then_initialize_test.dart
+++ b/test/unit/api/context/context_then_initialize_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/context/context_uninitialized_test.dart
+++ b/test/unit/api/context/context_uninitialized_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/context/isolate_transfer_test.dart
+++ b/test/unit/api/context/isolate_transfer_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/context/propagation/composite_propagator_test.dart
+++ b/test/unit/api/context/propagation/composite_propagator_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/factory/otel_api_factory_test.dart
+++ b/test/unit/api/factory/otel_api_factory_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // ignore_for_file: always_declare_return_types
 

--- a/test/unit/api/id/id_generator_test.dart
+++ b/test/unit/api/id/id_generator_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/src/api/id/id_generator.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/logs/log_provider_test.dart
+++ b/test/unit/api/logs/log_provider_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/src/api/common/attributes.dart';
 import 'package:dartastic_opentelemetry_api/src/api/otel_api.dart';

--- a/test/unit/api/logs/logger_test.dart
+++ b/test/unit/api/logs/logger_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/logs/severity_test.dart
+++ b/test/unit/api/logs/severity_test.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 import 'package:dartastic_opentelemetry_api/src/api/logs/severity.dart';
 import 'package:test/test.dart';
 

--- a/test/unit/api/metrics/counter_test.dart
+++ b/test/unit/api/metrics/counter_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/gauge_test.dart
+++ b/test/unit/api/metrics/gauge_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/histogram_test.dart
+++ b/test/unit/api/metrics/histogram_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/instrument_test.dart
+++ b/test/unit/api/metrics/instrument_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/measurement_test.dart
+++ b/test/unit/api/metrics/measurement_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/meter_provider_defaults_test.dart
+++ b/test/unit/api/metrics/meter_provider_defaults_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/meter_provider_test.dart
+++ b/test/unit/api/metrics/meter_provider_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/meter_test.dart
+++ b/test/unit/api/metrics/meter_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/metric_point_test.dart
+++ b/test/unit/api/metrics/metric_point_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:dartastic_opentelemetry_api/src/api/metrics/metric_point.dart';

--- a/test/unit/api/metrics/observable_callback_test.dart
+++ b/test/unit/api/metrics/observable_callback_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/observable_counter_test.dart
+++ b/test/unit/api/metrics/observable_counter_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/observable_gauge_test.dart
+++ b/test/unit/api/metrics/observable_gauge_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/observable_result_test.dart
+++ b/test/unit/api/metrics/observable_result_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/observable_up_down_counter_test.dart
+++ b/test/unit/api/metrics/observable_up_down_counter_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/metrics/up_down_counter_test.dart
+++ b/test/unit/api/metrics/up_down_counter_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/otel_api_attributes_factory_test.dart
+++ b/test/unit/api/otel_api_attributes_factory_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/otel_api_provider_lists_test.dart
+++ b/test/unit/api/otel_api_provider_lists_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/otel_api_test.dart
+++ b/test/unit/api/otel_api_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/otel_api_uninitialized_test.dart
+++ b/test/unit/api/otel_api_uninitialized_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/semantics/feature_file_host_resource_test.dart
+++ b/test/unit/api/semantics/feature_file_host_resource_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/semantics/lifecycle_state_test.dart
+++ b/test/unit/api/semantics/lifecycle_state_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/semantics/navigation_action_test.dart
+++ b/test/unit/api/semantics/navigation_action_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/semantics/resource_semantics_test.dart
+++ b/test/unit/api/semantics/resource_semantics_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/semantics/semantics_base_test.dart
+++ b/test/unit/api/semantics/semantics_base_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/semantics/semantics_test.dart
+++ b/test/unit/api/semantics/semantics_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/src/api/semantics/semantics.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/semantics/ui_semantics_test.dart
+++ b/test/unit/api/semantics/ui_semantics_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/span_context_coverage_test.dart
+++ b/test/unit/api/trace/span_context_coverage_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // ignore_for_file: avoid_dynamic_calls
 

--- a/test/unit/api/trace/span_context_create_test.dart
+++ b/test/unit/api/trace/span_context_create_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/span_context_from_json_uninitialized_test.dart
+++ b/test/unit/api/trace/span_context_from_json_uninitialized_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/span_context_test.dart
+++ b/test/unit/api/trace/span_context_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/span_coverage_test.dart
+++ b/test/unit/api/trace/span_coverage_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/span_event_test.dart
+++ b/test/unit/api/trace/span_event_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/span_exception_test.dart
+++ b/test/unit/api/trace/span_exception_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/src/api/common/attributes.dart';
 import 'package:dartastic_opentelemetry_api/src/api/otel_api.dart';

--- a/test/unit/api/trace/span_id_test.dart
+++ b/test/unit/api/trace/span_id_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/src/api/otel_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/span_link_test.dart
+++ b/test/unit/api/trace/span_link_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/span_root_validation_test.dart
+++ b/test/unit/api/trace/span_root_validation_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Coverage tests for APISpan / APISpanCreate root-span construction
 // and SpanContextCreate default fallbacks.

--- a/test/unit/api/trace/span_test.dart
+++ b/test/unit/api/trace/span_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/trace_flags_test.dart
+++ b/test/unit/api/trace/trace_flags_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/trace_id_test.dart
+++ b/test/unit/api/trace/trace_id_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:typed_data';
 

--- a/test/unit/api/trace/trace_span_test.dart
+++ b/test/unit/api/trace/trace_span_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/trace_state_test.dart
+++ b/test/unit/api/trace/trace_state_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/trace_state_uninitialized_test.dart
+++ b/test/unit/api/trace/trace_state_uninitialized_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/tracer_coverage_test.dart
+++ b/test/unit/api/trace/tracer_coverage_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/tracer_provider_defaults_test.dart
+++ b/test/unit/api/trace/tracer_provider_defaults_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/api/trace/tracer_provider_test.dart
+++ b/test/unit/api/trace/tracer_provider_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/src/api/common/attributes.dart';
 import 'package:dartastic_opentelemetry_api/src/api/otel_api.dart';

--- a/test/unit/api/trace/tracer_test.dart
+++ b/test/unit/api/trace/tracer_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/factory/otel_factory_test.dart
+++ b/test/unit/factory/otel_factory_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';

--- a/test/unit/util/otel_log_test.dart
+++ b/test/unit/util/otel_log_test.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 import 'dart:async';
 

--- a/test/unit/util/time_test.dart
+++ b/test/unit/util/time_test.dart
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 // dart
 import 'package:dartastic_opentelemetry_api/src/util/time.dart';
 import 'package:fixnum/fixnum.dart';

--- a/test/validate_tenant_format.dart
+++ b/test/validate_tenant_format.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 // Test script to validate the tenant format implementation
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';

--- a/tool/add_header.sh
+++ b/tool/add_header.sh
@@ -4,7 +4,8 @@
 
 # Define the header using a here-document that includes an extra blank line.
 read -r -d '' HEADER << 'EOF'
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 
 EOF
@@ -12,7 +13,7 @@ EOF
 # Find all .dart files in the current directory and subdirectories
 find . -type f -name "*.dart" | while IFS= read -r file; do
     # Check if the header is already present in the file to avoid duplicate headers
-    if ! grep -q "Licensed under the Apache License" "$file"; then
+    if ! grep -q "Copyright The OpenTelemetry Authors" "$file"; then
         echo "Adding header to $file"
         # Create a temporary file to hold the new content
         tmpfile=$(mktemp)

--- a/tool/release.dart
+++ b/tool/release.dart
@@ -1,4 +1,5 @@
-// Licensed under the Apache License, Version 2.0
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 /// Release script — Flutter / Dart team `-wip` pattern.
 ///


### PR DESCRIPTION
Replaces the per-file `// Licensed under the Apache License, Version 2.0` line with the standard OpenTelemetry header used across CNCF OTel repos, ahead of the transfer to the `open-telemetry` org (MindfulSoftwareLLC/dartastic_opentelemetry#57):

```dart
// Copyright The OpenTelemetry Authors
// SPDX-License-Identifier: Apache-2.0
```

Also adds the header to 11 files that had none, and updates `tool/add_header.sh` to emit and detect the new form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)