### PR TITLE
chore: enforce *Create classes as package-internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`*Create` classes are now `@internal` and hidden from the public library.**
+  They were internal by doc-comment convention only; the barrel exported them,
+  so `AttributesCreate.create()` etc. were callable by any consumer — an open
+  factory-bypass door, contradicting the beta.8/9 removal of factory cheat
+  paths. The analyzer now rejects outside-package use
+  (`invalid_use_of_internal_member`). Factories and same-package code are
+  unaffected. Consumers constructing objects must go through `OTelAPI` or the
+  installed `OTelFactory`. Covers all 29 `*Create` classes, including the
+  new `CompositePropagatorCreate`.
+
 - **Breaking: the semantic-convention enums are now generated from the
   OpenTelemetry registry with OTel Weaver, one file per registry
   namespace** (#50, #51). The hand-written `semantics.dart`,

--- a/lib/dartastic_opentelemetry_api.dart
+++ b/lib/dartastic_opentelemetry_api.dart
@@ -12,17 +12,19 @@
 library;
 
 // Baggage
-export 'src/api/baggage/baggage.dart';
+export 'src/api/baggage/baggage.dart' hide BaggageCreate;
 export 'src/api/baggage/baggage_entry.dart';
 // Common
-export 'src/api/common/attribute.dart';
-export 'src/api/common/attributes.dart';
-export 'src/api/common/instrumentation_scope.dart';
+export 'src/api/common/attribute.dart' hide AttributeCreate;
+export 'src/api/common/attributes.dart' hide AttributesCreate;
+export 'src/api/common/instrumentation_scope.dart'
+    hide InstrumentationScopeCreate;
 export 'src/api/common/timestamp.dart';
 // Context
-export 'src/api/context/context.dart';
-export 'src/api/context/context_key.dart';
-export 'src/api/context/propagation/composite_propagator.dart';
+export 'src/api/context/context.dart' hide ContextCreate;
+export 'src/api/context/context_key.dart' hide ContextKeyCreate;
+export 'src/api/context/propagation/composite_propagator.dart'
+    hide CompositePropagatorCreate;
 export 'src/api/context/propagation/context_propagator.dart';
 export 'src/api/context/propagation/noop_text_map_propagator.dart';
 export 'src/api/context/propagation/text_map_propagator.dart';
@@ -31,23 +33,24 @@ export 'src/api/factory/otel_api_factory.dart';
 export 'src/api/id/id_generator.dart';
 // Log
 export 'src/api/logs/log_record.dart';
-export 'src/api/logs/logger.dart';
-export 'src/api/logs/logger_provider.dart';
+export 'src/api/logs/logger.dart' hide LoggerCreate;
+export 'src/api/logs/logger_provider.dart' hide LogProviderCreate;
 export 'src/api/logs/severity.dart';
 //Metrics
-export 'src/api/metrics/counter.dart';
-export 'src/api/metrics/gauge.dart';
-export 'src/api/metrics/histogram.dart';
+export 'src/api/metrics/counter.dart' hide CounterCreate;
+export 'src/api/metrics/gauge.dart' hide GaugeCreate;
+export 'src/api/metrics/histogram.dart' hide HistogramCreate;
 export 'src/api/metrics/instrument.dart';
-export 'src/api/metrics/measurement.dart';
-export 'src/api/metrics/meter.dart';
-export 'src/api/metrics/meter_provider.dart';
+export 'src/api/metrics/measurement.dart' hide MeasurementCreate;
+export 'src/api/metrics/meter.dart' hide APIMeterCreate;
+export 'src/api/metrics/meter_provider.dart' hide MeterProviderCreate;
 export 'src/api/metrics/observable_callback.dart';
-export 'src/api/metrics/observable_counter.dart';
-export 'src/api/metrics/observable_gauge.dart';
+export 'src/api/metrics/observable_counter.dart' hide ObservableCounterCreate;
+export 'src/api/metrics/observable_gauge.dart' hide ObservableGaugeCreate;
 export 'src/api/metrics/observable_result.dart';
-export 'src/api/metrics/observable_up_down_counter.dart';
-export 'src/api/metrics/up_down_counter.dart';
+export 'src/api/metrics/observable_up_down_counter.dart'
+    hide ObservableUpDownCounterCreate;
+export 'src/api/metrics/up_down_counter.dart' hide UpDownCounterCreate;
 // API
 export 'src/api/otel_api.dart';
 // Semantics
@@ -56,17 +59,17 @@ export 'src/api/semantics/rum.dart';
 export 'src/api/semantics/semantics_base.dart';
 export 'src/api/semantics/semconv/semconv.dart';
 // Trace
-export 'src/api/trace/span.dart';
-export 'src/api/trace/span_context.dart';
-export 'src/api/trace/span_event.dart';
-export 'src/api/trace/span_id.dart';
+export 'src/api/trace/span.dart' hide APISpanCreate;
+export 'src/api/trace/span_context.dart' hide SpanContextCreate;
+export 'src/api/trace/span_event.dart' hide SpanEventCreate;
+export 'src/api/trace/span_id.dart' hide SpanIdCreate;
 export 'src/api/trace/span_kind.dart';
-export 'src/api/trace/span_link.dart';
-export 'src/api/trace/trace_flags.dart';
-export 'src/api/trace/trace_id.dart';
-export 'src/api/trace/trace_state.dart';
-export 'src/api/trace/tracer.dart';
-export 'src/api/trace/tracer_provider.dart';
+export 'src/api/trace/span_link.dart' hide SpanLinkCreate;
+export 'src/api/trace/trace_flags.dart' hide TraceFlagsCreate;
+export 'src/api/trace/trace_id.dart' hide TraceIdCreate;
+export 'src/api/trace/trace_state.dart' hide TraceStateCreate;
+export 'src/api/trace/tracer.dart' hide TracerCreate;
+export 'src/api/trace/tracer_provider.dart' hide TracerProviderCreate;
 export 'src/factory/otel_factory.dart';
 // Util
 export 'src/util/default_time_provider.dart';

--- a/lib/src/api/baggage/baggage.dart
+++ b/lib/src/api/baggage/baggage.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
-
 import '../../factory/otel_factory.dart';
 import '../../util/otel_log.dart';
 import 'baggage_entry.dart';

--- a/lib/src/api/baggage/baggage_create.dart
+++ b/lib/src/api/baggage/baggage_create.dart
@@ -5,6 +5,7 @@ part of 'baggage.dart';
 
 /// Factory for creating Baggage instances.
 /// This is used internally by the OpenTelemetry API implementation.
+@internal
 class BaggageCreate {
   /// Creates a new Baggage instance with the specified entries.
   ///

--- a/lib/src/api/common/attribute_create.dart
+++ b/lib/src/api/common/attribute_create.dart
@@ -6,6 +6,7 @@ part of 'attribute.dart';
 /// Factory class for creating Attribute instances.
 /// This class is not intended to be used directly by users.
 /// Instead, use the methods provided by the OpenTelemetry API.
+@internal
 class AttributeCreate {
   /// Creates a new Attribute with the specified name and value.
   ///

--- a/lib/src/api/common/attributes.dart
+++ b/lib/src/api/common/attributes.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
-
 import '../../factory/otel_factory.dart';
 import '../../util/otel_log.dart';
 import 'attribute.dart';

--- a/lib/src/api/common/attributes_create.dart
+++ b/lib/src/api/common/attributes_create.dart
@@ -7,6 +7,7 @@ part of 'attributes.dart';
 /// Used internally and not exported to respect factories.
 /// This class is not intended to be used directly by users.
 /// Instead, use the methods provided by the OpenTelemetry API.
+@internal
 class AttributesCreate {
   /// Creates a new Attributes instance containing the specified attributes.
   ///

--- a/lib/src/api/common/instrumentation_scope.dart
+++ b/lib/src/api/common/instrumentation_scope.dart
@@ -3,6 +3,7 @@
 
 library;
 
+import 'package:meta/meta.dart';
 import '../otel_api.dart';
 import 'attributes.dart';
 

--- a/lib/src/api/common/instrumentation_scope_create.dart
+++ b/lib/src/api/common/instrumentation_scope_create.dart
@@ -7,6 +7,7 @@ part of 'instrumentation_scope.dart';
 /// Used internally and not exported to respect factories.
 /// This class is not intended to be used directly by users.
 /// Instead, use the methods provided by the [OTelAPI].
+@internal
 class InstrumentationScopeCreate {
   /// Creates a new InstrumentationScope instance containing the specified attributes.
   /// [name] is required and represents the instrumentation scope name (e.g. 'io.opentelemetry.contrib.mongodb')

--- a/lib/src/api/common/timestamp.dart
+++ b/lib/src/api/common/timestamp.dart
@@ -3,7 +3,6 @@
 
 import 'package:fixnum/fixnum.dart';
 import 'package:meta/meta.dart';
-
 import '../../util/time.dart';
 
 /// Utility class for working with OpenTelemetry timestamps.

--- a/lib/src/api/context/context.dart
+++ b/lib/src/api/context/context.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
-
 import '../../factory/otel_factory.dart';
 import '../baggage/baggage.dart';
 import '../trace/span.dart';

--- a/lib/src/api/context/context_create.dart
+++ b/lib/src/api/context/context_create.dart
@@ -6,6 +6,7 @@ part of 'context.dart';
 /// Factory class for creating Context instances.
 ///
 /// This is a part of the Context library and not meant to be used directly.
+@internal
 class ContextCreate {
   /// Creates a new Context with the given context map and optional baggage.
   ///

--- a/lib/src/api/context/context_key.dart
+++ b/lib/src/api/context/context_key.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:typed_data';
+import 'package:meta/meta.dart';
 import '../id/id_generator.dart';
 
 part 'context_key_create.dart';

--- a/lib/src/api/context/context_key_create.dart
+++ b/lib/src/api/context/context_key_create.dart
@@ -6,6 +6,7 @@ part of 'context_key.dart';
 /// Factory class for creating ContextKey instances.
 ///
 /// This is a part of the Context library and not meant to be used directly.
+@internal
 class ContextKeyCreate<T> {
   /// Creates a new ContextKey with the specified name and unique identifier.
   ///

--- a/lib/src/api/context/propagation/composite_propagator.dart
+++ b/lib/src/api/context/propagation/composite_propagator.dart
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
+
 import '../context.dart';
 import 'text_map_propagator.dart';
 
@@ -45,6 +47,7 @@ class CompositePropagator<C, V> implements TextMapPropagator<C, V> {
 /// Internal constructor access for [CompositePropagator].
 /// Used by `OTelFactory` implementations; users should create composite
 /// propagators with `OTelAPI.compositePropagator`.
+@internal
 class CompositePropagatorCreate {
   /// Creates a [CompositePropagator] delegating to [propagators].
   static CompositePropagator<C, V> create<C, V>(

--- a/lib/src/api/context/propagation/context_propagator.dart
+++ b/lib/src/api/context/propagation/context_propagator.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
-
 import '../context.dart';
 
 /// A propagator for binary values that can inject into and extract from a carrier.

--- a/lib/src/api/logs/logger.dart
+++ b/lib/src/api/logs/logger.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import '../common/attributes.dart';
 import '../context/context.dart';
 import 'severity.dart';

--- a/lib/src/api/logs/logger_create.dart
+++ b/lib/src/api/logs/logger_create.dart
@@ -3,6 +3,7 @@
 
 part of 'logger.dart';
 
+@internal
 class LoggerCreate {
   /// Creates a Logger, only accessible within library
   static APILogger create({

--- a/lib/src/api/logs/logger_provider.dart
+++ b/lib/src/api/logs/logger_provider.dart
@@ -3,6 +3,7 @@
 
 // ignore_for_file: unnecessary_getters_setters
 
+import 'package:meta/meta.dart';
 import '../../util/otel_log.dart';
 import '../common/attributes.dart';
 import '../common/signal_instance_key.dart';

--- a/lib/src/api/logs/logger_provider_create.dart
+++ b/lib/src/api/logs/logger_provider_create.dart
@@ -3,6 +3,7 @@
 
 part of 'logger_provider.dart';
 
+@internal
 class LogProviderCreate {
   /// Creates a new [APIMeterProvider] instance.
   /// This is an implementation detail and should not be used directly.

--- a/lib/src/api/metrics/counter.dart
+++ b/lib/src/api/metrics/counter.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import '../common/attributes.dart';
 import 'meter.dart';
 

--- a/lib/src/api/metrics/counter_create.dart
+++ b/lib/src/api/metrics/counter_create.dart
@@ -5,6 +5,7 @@ part of 'counter.dart';
 
 /// Factory methods for creating [APICounter] instances.
 /// This is part of the counter.dart file to keep related code together.
+@internal
 class CounterCreate {
   /// Creates a new [APICounter] instance.
   /// This is an implementation detail and should not be used directly.

--- a/lib/src/api/metrics/gauge.dart
+++ b/lib/src/api/metrics/gauge.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import '../common/attributes.dart';
 import 'meter.dart';
 

--- a/lib/src/api/metrics/gauge_create.dart
+++ b/lib/src/api/metrics/gauge_create.dart
@@ -5,6 +5,7 @@ part of 'gauge.dart';
 
 /// Factory methods for creating [APIGauge] instances.
 /// This is part of the gauge.dart file to keep related code together.
+@internal
 class GaugeCreate {
   /// Creates a new [APIGauge] instance.
   /// This is an implementation detail and should not be used directly.

--- a/lib/src/api/metrics/histogram.dart
+++ b/lib/src/api/metrics/histogram.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import '../common/attributes.dart';
 import 'meter.dart';
 

--- a/lib/src/api/metrics/histogram_create.dart
+++ b/lib/src/api/metrics/histogram_create.dart
@@ -5,6 +5,7 @@ part of 'histogram.dart';
 
 /// Factory methods for creating [APIHistogram] instances.
 /// This is part of the histogram.dart file to keep related code together.
+@internal
 class HistogramCreate {
   /// Creates a new [APIHistogram] instance.
   /// This is an implementation detail and should not be used directly.

--- a/lib/src/api/metrics/measurement.dart
+++ b/lib/src/api/metrics/measurement.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import '../common/attributes.dart';
 
 part 'measurement_create.dart';

--- a/lib/src/api/metrics/measurement_create.dart
+++ b/lib/src/api/metrics/measurement_create.dart
@@ -4,6 +4,7 @@
 part of 'measurement.dart';
 
 /// Factory methods for creating [Measurement] instances.
+@internal
 class MeasurementCreate<T extends num> {
   /// Creates a new [Measurement] instance.
   /// This is an implementation detail and should not be used directly.

--- a/lib/src/api/metrics/meter.dart
+++ b/lib/src/api/metrics/meter.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import '../common/attributes.dart';
 import '../otel_api.dart';
 import 'counter.dart';

--- a/lib/src/api/metrics/meter_create.dart
+++ b/lib/src/api/metrics/meter_create.dart
@@ -7,6 +7,7 @@ part of 'meter.dart';
 /// This is part of the meter.dart file to keep related code together.
 /// Factory class for creating APIMeter instances.
 /// This class is internal and should not be used directly by application code.
+@internal
 class APIMeterCreate {
   /// Creates a new [APIMeter] instance with the specified parameters.
   /// This is an implementation detail and should not be used directly.

--- a/lib/src/api/metrics/meter_provider.dart
+++ b/lib/src/api/metrics/meter_provider.dart
@@ -3,6 +3,7 @@
 
 // ignore_for_file: unnecessary_getters_setters
 
+import 'package:meta/meta.dart';
 import '../../util/otel_log.dart';
 import '../common/attributes.dart';
 import '../common/signal_instance_key.dart';

--- a/lib/src/api/metrics/meter_provider_create.dart
+++ b/lib/src/api/metrics/meter_provider_create.dart
@@ -4,6 +4,7 @@
 part of 'meter_provider.dart';
 
 /// Factory methods for creating [APIMeterProvider] instances.
+@internal
 class MeterProviderCreate {
   /// Creates a new [APIMeterProvider] instance.
   /// This is an implementation detail and should not be used directly.

--- a/lib/src/api/metrics/observable_counter.dart
+++ b/lib/src/api/metrics/observable_counter.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import 'measurement.dart';
 import 'meter.dart';
 import 'observable_callback.dart';

--- a/lib/src/api/metrics/observable_counter_create.dart
+++ b/lib/src/api/metrics/observable_counter_create.dart
@@ -5,6 +5,7 @@ part of 'observable_counter.dart';
 
 /// Factory methods for creating [APIObservableCounter] instances.
 /// This is part of the observable_counter.dart file to keep related code together.
+@internal
 class ObservableCounterCreate {
   /// Creates a new [APIObservableCounter] instance.
   /// This is an implementation detail and should not be used directly.

--- a/lib/src/api/metrics/observable_gauge.dart
+++ b/lib/src/api/metrics/observable_gauge.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import 'measurement.dart';
 import 'meter.dart';
 import 'observable_callback.dart';

--- a/lib/src/api/metrics/observable_gauge_create.dart
+++ b/lib/src/api/metrics/observable_gauge_create.dart
@@ -5,6 +5,7 @@ part of 'observable_gauge.dart';
 
 /// Factory methods for creating [APIObservableGauge] instances.
 /// This is part of the observable_gauge.dart file to keep related code together.
+@internal
 class ObservableGaugeCreate {
   /// Creates a new [APIObservableGauge] instance.
   /// This is an implementation detail and should not be used directly.

--- a/lib/src/api/metrics/observable_up_down_counter.dart
+++ b/lib/src/api/metrics/observable_up_down_counter.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import 'measurement.dart';
 import 'meter.dart';
 import 'observable_callback.dart';

--- a/lib/src/api/metrics/observable_up_down_counter_create.dart
+++ b/lib/src/api/metrics/observable_up_down_counter_create.dart
@@ -5,6 +5,7 @@ part of 'observable_up_down_counter.dart';
 
 /// Factory methods for creating [APIObservableUpDownCounter] instances.
 /// This is part of the observable_up_down_counter.dart file to keep related code together.
+@internal
 class ObservableUpDownCounterCreate<T extends num> {
   /// Creates a new [APIObservableUpDownCounter] instance.
   /// This is an implementation detail and should not be used directly.

--- a/lib/src/api/metrics/up_down_counter.dart
+++ b/lib/src/api/metrics/up_down_counter.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import '../common/attributes.dart';
 import 'meter.dart';
 

--- a/lib/src/api/metrics/up_down_counter_create.dart
+++ b/lib/src/api/metrics/up_down_counter_create.dart
@@ -5,6 +5,7 @@ part of 'up_down_counter.dart';
 
 /// Factory methods for creating [APIUpDownCounter] instances.
 /// This is part of the up_down_counter.dart file to keep related code together.
+@internal
 class UpDownCounterCreate {
   /// Creates a new [APIUpDownCounter] instance.
   /// This is an implementation detail and should not be used directly.

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -4,7 +4,6 @@
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
-
 import '../factory/otel_factory.dart';
 import '../util/otel_log.dart';
 import 'baggage/baggage.dart';

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
-
 import '../../factory/otel_factory.dart';
 import '../../util/default_time_provider.dart';
 import '../../util/time_provider.dart';

--- a/lib/src/api/trace/span_context.dart
+++ b/lib/src/api/trace/span_context.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import '../../factory/otel_factory.dart';
 import '../otel_api.dart';
 import 'span_id.dart';

--- a/lib/src/api/trace/span_context_create.dart
+++ b/lib/src/api/trace/span_context_create.dart
@@ -4,6 +4,7 @@
 part of 'span_context.dart';
 
 /// Internal constructor access for Span
+@internal
 class SpanContextCreate {
   /// Creates a Span, only accessible within library
   static SpanContext create({

--- a/lib/src/api/trace/span_create.dart
+++ b/lib/src/api/trace/span_create.dart
@@ -4,6 +4,7 @@
 part of 'span.dart';
 
 /// Internal constructor access for Span
+@internal
 class APISpanCreate {
   /// Creates a new APISpan instance with the specified parameters.
   /// This constructor is only accessible within the library and is used by the internal factory methods.

--- a/lib/src/api/trace/span_event.dart
+++ b/lib/src/api/trace/span_event.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
-
 import '../common/attributes.dart';
 
 part 'span_event_create.dart';

--- a/lib/src/api/trace/span_event_create.dart
+++ b/lib/src/api/trace/span_event_create.dart
@@ -7,6 +7,7 @@ part of 'span_event.dart';
 ///
 /// This is a part of the OpenTelemetry API implementation and not meant
 /// to be used directly by application code.
+@internal
 class SpanEventCreate {
   /// Creates a new SpanEvent with the given parameters.
   ///

--- a/lib/src/api/trace/span_id.dart
+++ b/lib/src/api/trace/span_id.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'dart:typed_data';
+import 'package:meta/meta.dart';
 import '../id/id_generator.dart';
 
 part 'span_id_create.dart';

--- a/lib/src/api/trace/span_id_create.dart
+++ b/lib/src/api/trace/span_id_create.dart
@@ -7,6 +7,7 @@ part of 'span_id.dart';
 ///
 /// This is a part of the OpenTelemetry API implementation and not meant
 /// to be used directly by application code.
+@internal
 class SpanIdCreate {
   /// Creates a new SpanId from the provided bytes.
   ///

--- a/lib/src/api/trace/span_link.dart
+++ b/lib/src/api/trace/span_link.dart
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
-
 import '../../factory/otel_factory.dart';
 import '../common/attributes.dart';
 import 'span_context.dart';

--- a/lib/src/api/trace/span_link_create.dart
+++ b/lib/src/api/trace/span_link_create.dart
@@ -4,6 +4,7 @@
 part of 'span_link.dart';
 
 /// Internal constructor access for SpanLink
+@internal
 class SpanLinkCreate {
   /// Creates a SpanLink, only accessible within library
   static SpanLink create({

--- a/lib/src/api/trace/trace_flags.dart
+++ b/lib/src/api/trace/trace_flags.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import 'span_context.dart' show SpanContext;
 
 part 'trace_flags_create.dart';

--- a/lib/src/api/trace/trace_flags_create.dart
+++ b/lib/src/api/trace/trace_flags_create.dart
@@ -4,6 +4,7 @@
 part of 'trace_flags.dart';
 
 /// Internal constructor access for TraceFlags
+@internal
 class TraceFlagsCreate {
   /// Creates a TraceFlags, only accessible within library
   static TraceFlags create([int? flags]) {

--- a/lib/src/api/trace/trace_id.dart
+++ b/lib/src/api/trace/trace_id.dart
@@ -4,7 +4,6 @@
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
-
 import '../id/id_generator.dart';
 
 part 'trace_id_create.dart';

--- a/lib/src/api/trace/trace_id_create.dart
+++ b/lib/src/api/trace/trace_id_create.dart
@@ -7,6 +7,7 @@ part of 'trace_id.dart';
 ///
 /// This is a part of the OpenTelemetry API implementation and not meant
 /// to be used directly by application code.
+@internal
 class TraceIdCreate {
   /// Creates a new TraceId from the provided bytes.
   ///

--- a/lib/src/api/trace/trace_state.dart
+++ b/lib/src/api/trace/trace_state.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import '../../factory/otel_factory.dart';
 import '../../util/otel_log.dart';
 

--- a/lib/src/api/trace/trace_state_create.dart
+++ b/lib/src/api/trace/trace_state_create.dart
@@ -4,6 +4,7 @@
 part of 'trace_state.dart';
 
 /// Internal constructor access for TraceState
+@internal
 class TraceStateCreate {
   /// Creates a TraceState, only accessible within library
   /// Enforces 32 key-value pair limit per W3C spec

--- a/lib/src/api/trace/tracer.dart
+++ b/lib/src/api/trace/tracer.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
 import '../../factory/otel_factory.dart';
 import '../../util/default_time_provider.dart';
 import '../../util/time_provider.dart';

--- a/lib/src/api/trace/tracer_create.dart
+++ b/lib/src/api/trace/tracer_create.dart
@@ -4,6 +4,7 @@
 part of 'tracer.dart';
 
 /// Internal constructor access for Tracer
+@internal
 class TracerCreate {
   /// Creates a Tracer, only accessible within library
   static APITracer create({

--- a/lib/src/api/trace/tracer_provider.dart
+++ b/lib/src/api/trace/tracer_provider.dart
@@ -3,6 +3,7 @@
 
 // ignore_for_file: unnecessary_getters_setters
 
+import 'package:meta/meta.dart';
 import '../../util/default_time_provider.dart';
 import '../../util/otel_log.dart';
 import '../../util/time_provider.dart';

--- a/lib/src/api/trace/tracer_provider_create.dart
+++ b/lib/src/api/trace/tracer_provider_create.dart
@@ -4,6 +4,7 @@
 part of 'tracer_provider.dart';
 
 /// Internal constructor access for TracerProvider
+@internal
 class TracerProviderCreate {
   /// Creates a TracerProvider, only accessible within library
   static APITracerProvider create(


### PR DESCRIPTION
Companion to MindfulSoftwareLLC/dartastic_opentelemetry#62 (which applied the same lockdown to the SDK's Create classes).

## Why

The `*Create` classes were internal by doc-comment convention only. They're public classes in `part` files of barrel-exported libraries, so `AttributesCreate.create()` etc. were callable by any consumer — an open factory-bypass door, contradicting the beta.8/9 removal of factory cheat paths. (The SDK itself used `AttributesCreate` that way until #62 removed it.) The `part of` + private-constructor pattern protects the *constructors*; the public Create wrappers were exactly a public door to them.

## What

- `@internal` (package:meta) on all 28 `*Create` classes — analyzer rejects outside-package use (`invalid_use_of_internal_member`), dartdoc hides them
- Barrel `hide`s them, enforced by `invalid_export_of_internal_element`
- `meta` imports added to host libraries
- Factories, same-package code, and tests are unaffected

## Validation

- `dart analyze lib test`: no issues
- Full suite: 753 passed, 0 failures
- The SDK no longer references any API Create class (verified in #62), so releasing this as beta.10 breaks nothing downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)