### PR TITLE
feat: first-class W3C multi-tenant tracestate keys (tenant-id@system-id)

### DIFF
--- a/lib/src/api/trace/trace_state.dart
+++ b/lib/src/api/trace/trace_state.dart
@@ -102,6 +102,54 @@ class TraceState {
     return OTelFactory.otelFactory!.traceState(newEntries);
   }
 
+  // ── W3C multi-tenant keys ─────────────────────────────────────────────
+  // The W3C Trace Context spec defines a SECOND key form for tracestate
+  // list members: `{tenant-id}@{system-id}` — "in the case of multi-tenant
+  // vendors, the key SHOULD be in this format". OpenTelemetry surfaces no
+  // API for it anywhere (upstream gap); these helpers make the standard
+  // form first-class while staying vendor-neutral: any (tenant, system)
+  // pair, no Dartastic-specific behavior.
+
+  /// The W3C multi-tenant tracestate key for ([tenantId], [systemId]) —
+  /// `tenant-id@system-id`. Throws [ArgumentError] when either part
+  /// violates the spec grammar (tenant-id: `(lcalpha / DIGIT)` then up to
+  /// 240 of `lcalpha / DIGIT / "_" / "-" / "*" / "/"`; system-id: `lcalpha`
+  /// then up to 13 of the same set).
+  static String multiTenantKey(String tenantId, String systemId) {
+    if (!_tenantIdFormat.hasMatch(tenantId)) {
+      throw ArgumentError.value(
+          tenantId, 'tenantId', 'Invalid W3C tracestate tenant-id');
+    }
+    if (!_systemIdFormat.hasMatch(systemId)) {
+      throw ArgumentError.value(
+          systemId, 'systemId', 'Invalid W3C tracestate system-id');
+    }
+    return '$tenantId@$systemId';
+  }
+
+  /// Creates a new [TraceState] with the multi-tenant entry
+  /// `tenantId@systemId=value` added (or updated), per the W3C
+  /// multi-tenant key form. Same freshness/limit semantics as [put].
+  TraceState putMultiTenant(String tenantId, String systemId, String value) =>
+      put(multiTenantKey(tenantId, systemId), value);
+
+  /// The value of the multi-tenant entry for ([tenantId], [systemId]),
+  /// or null when absent.
+  String? getMultiTenant(String tenantId, String systemId) =>
+      _entries['$tenantId@$systemId'];
+
+  /// Every multi-tenant entry belonging to [systemId], as tenant-id → value.
+  /// Empty when the system has no entries (never null).
+  Map<String, String> tenantsForSystem(String systemId) {
+    final suffix = '@$systemId';
+    return Map.unmodifiable({
+      for (final e in _entries.entries)
+        if (e.key.endsWith(suffix) &&
+            e.key.indexOf('@') == e.key.length - suffix.length)
+          e.key.substring(0, e.key.length - suffix.length): e.value,
+    });
+  }
+
   ///  Creates a new [TraceState] with the given [key] removed.
   TraceState remove(String key) {
     if (OTelFactory.otelFactory == null) {

--- a/test/unit/api/trace/trace_state_multi_tenant_test.dart
+++ b/test/unit/api/trace/trace_state_multi_tenant_test.dart
@@ -69,8 +69,8 @@ void main() {
 
     test('is unmodifiable', () {
       final ts = OTelAPI.traceState({}).putMultiTenant('acme', 'dt', 'v');
-      expect(() => ts.tenantsForSystem('dt')['x'] = 'y',
-          throwsUnsupportedError);
+      expect(
+          () => ts.tenantsForSystem('dt')['x'] = 'y', throwsUnsupportedError);
     });
   });
 }

--- a/test/unit/api/trace/trace_state_multi_tenant_test.dart
+++ b/test/unit/api/trace/trace_state_multi_tenant_test.dart
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// W3C Trace Context multi-tenant tracestate keys (`{tenant-id}@{system-id}`)
+// — the spec's second key form, which OpenTelemetry surfaces no API for.
+// Validation of the form itself is covered in trace_state_test.dart; these
+// tests cover the first-class helpers.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  setUp(() {
+    OTelAPI.reset();
+    OTelAPI.initialize(
+      endpoint: 'http://localhost:4317',
+      serviceName: 'test-service',
+      serviceVersion: '1.0.0',
+    );
+  });
+
+  group('multiTenantKey', () {
+    test('builds the spec form', () {
+      expect(TraceState.multiTenantKey('acme', 'dartastic'), 'acme@dartastic');
+      // W3C example shape: digit-leading tenant ids are legal.
+      expect(TraceState.multiTenantKey('0mgorg', 'dt'), '0mgorg@dt');
+    });
+
+    test('throws on invalid parts (fail fast, no silent mangling)', () {
+      expect(() => TraceState.multiTenantKey('BAD', 'dartastic'),
+          throwsArgumentError); // uppercase tenant
+      expect(() => TraceState.multiTenantKey('acme', '1sys'),
+          throwsArgumentError); // system-id must start lcalpha
+      expect(() => TraceState.multiTenantKey('acme', 'a' * 15),
+          throwsArgumentError); // system-id > 14
+      expect(() => TraceState.multiTenantKey('a' * 242, 'dt'),
+          throwsArgumentError); // tenant-id > 241
+    });
+  });
+
+  group('put/get multi-tenant entries', () {
+    test('round-trips and serializes per W3C', () {
+      final ts = OTelAPI.traceState({})
+          .putMultiTenant('acme', 'dartastic', 'span-affinity')
+          .put('simple', 'x');
+      expect(ts.getMultiTenant('acme', 'dartastic'), 'span-affinity');
+      expect(ts.toString(), contains('acme@dartastic=span-affinity'));
+      // Survives header round-trip.
+      final parsed = TraceState.fromString(ts.toString());
+      expect(parsed.getMultiTenant('acme', 'dartastic'), 'span-affinity');
+    });
+
+    test('getMultiTenant is null when absent', () {
+      expect(OTelAPI.traceState({}).getMultiTenant('no', 'body'), isNull);
+    });
+  });
+
+  group('tenantsForSystem', () {
+    test('collects only the system’s tenants', () {
+      final ts = OTelAPI.traceState({})
+          .putMultiTenant('acme', 'dartastic', 'a')
+          .putMultiTenant('globex', 'dartastic', 'b')
+          .putMultiTenant('acme', 'dt', 'c')
+          .put('plain', 'd');
+      expect(ts.tenantsForSystem('dartastic'), {'acme': 'a', 'globex': 'b'});
+      expect(ts.tenantsForSystem('dt'), {'acme': 'c'});
+      expect(ts.tenantsForSystem('nobody'), isEmpty);
+    });
+
+    test('is unmodifiable', () {
+      final ts = OTelAPI.traceState({}).putMultiTenant('acme', 'dt', 'v');
+      expect(() => ts.tenantsForSystem('dt')['x'] = 'y',
+          throwsUnsupportedError);
+    });
+  });
+}


### PR DESCRIPTION
The W3C Trace Context spec defines a second `tracestate` key form — **`{tenant-id}@{system-id}`** ("in the case of multi-tenant vendors, the key SHOULD be in this format") — which OpenTelemetry surfaces **no API for anywhere**. This library already *validated* the form (parsing accepts it, grammar-checked); this PR makes it first-class, vendor-neutrally:

- `TraceState.multiTenantKey(tenantId, systemId)` — builds the spec form; **throws** on grammar violations (tenant-id ≤ 241 chars starting `lcalpha/DIGIT`; system-id ≤ 14 starting `lcalpha`) — fail fast, no silent mangling
- `putMultiTenant` / `getMultiTenant` — entry round-trip with `put()`'s freshness/limit semantics
- `tenantsForSystem(systemId)` — all of a system's tenant entries as an unmodifiable `tenantId → value` map

Tests cover the spec's boundary lengths, digit-leading tenant ids, header serialization round-trip, and multi-system separation. Full suite green.

No Dartastic-specific behavior lives here — any `(tenant, system)` pair works, which also makes this a clean candidate to propose upstream (the OTel API's TraceState has nothing equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)