### PR TITLE
fix!: no-SDK spans are non-recording and carry the parent SpanContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   event, and entity against the registry, plus source audits for
   `@Deprecated`/`Stability:` annotations.
 
+- `NonRecordingSpan` and `OTelAPI.nonRecordingSpan(SpanContext)` — the
+  spec's "Wrapping a SpanContext in a Span" operation: the wrapped
+  context is returned unchanged, `isRecording` is `false`, and all other
+  operations are no-ops (#40).
+
 ### Deprecated
 
 - **All vendor/RUM enums** — they are not OpenTelemetry semantic
@@ -301,6 +306,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `FeatureFlag.featureFlagProviderName` | `feature_flag.provider_name` | same identifier, now `feature_flag.provider.name` |
   | `CloudPlatform.azureVm`/`azureAks`/`azureFunctions`/`azureAppService`/`azureOpenshift`/`azureContainerApps`/`azureContainerInstances` | `azure_vm` etc. | same identifiers, now the registry's dotted values `azure.vm`, `azure.aks`, `azure.functions`, `azure.app_service`, `azure.openshift`, `azure.container_apps`, `azure.container_instances` |
   | `GenAiTokenType.completion` | `completion` | same identifier (`@Deprecated`), now emits `output`; new member `GenAiTokenType.output` |
+
+- **Breaking:** With only the API installed (no SDK), `startSpan`/`createSpan`
+  now follow trace/api.md's "Behavior of the API in the absence of an
+  installed SDK": the returned span is non-recording (`isRecording` is
+  `false` and every mutating operation is a no-op) and carries the
+  `SpanContext` from the parent `Context` — explicit or implicit —
+  unchanged; when the context has no span, it carries an empty
+  `SpanContext` (all-zero trace/span IDs, unsampled flags). Previously
+  the API minted random valid IDs and returned recording spans (#40).
+  SDK span creation is unaffected: the no-op behavior applies only when
+  the installed factory `isAPIFactory`.
 
 ## [1.0.0-beta.9] - 2026-07-11
 

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -29,6 +29,7 @@ import 'metrics/observable_gauge.dart';
 import 'metrics/observable_up_down_counter.dart';
 import 'metrics/up_down_counter.dart';
 import 'semantics/semantics_base.dart';
+import 'trace/span.dart';
 import 'trace/span_context.dart';
 import 'trace/span_event.dart';
 import 'trace/span_id.dart';
@@ -330,6 +331,16 @@ class OTelAPI {
   static SpanContext spanContextInvalid() {
     _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.spanContextInvalid();
+  }
+
+  /// Wraps a [SpanContext] in a non-recording span, per the spec
+  /// (trace/api.md, "Wrapping a SpanContext in a Span"): the returned
+  /// span's [APISpan.spanContext] is [spanContext] unchanged,
+  /// [APISpan.isRecording] is `false`, and every other operation is a
+  /// no-op.
+  static APISpan nonRecordingSpan(SpanContext spanContext) {
+    _getAndCacheOtelFactory();
+    return NonRecordingSpan(spanContext);
   }
 
   /// Creates a span event with the current timestamp.

--- a/lib/src/api/trace/non_recording_span.dart
+++ b/lib/src/api/trace/non_recording_span.dart
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+part of 'span.dart';
+
+/// A non-recording [APISpan] that carries a [SpanContext] without
+/// recording anything.
+///
+/// This is the span the OpenTelemetry specification requires in two
+/// places (trace/api.md):
+///
+/// - "Wrapping a SpanContext in a Span": "The API MUST provide an
+///   operation for wrapping a `SpanContext` with an object implementing
+///   the `Span` interface. [...] SHOULD be named `NonRecordingSpan`."
+///   `getContext` (the [spanContext] getter) returns the wrapped
+///   context, [isRecording] returns `false`, and all other operations
+///   are no-ops.
+/// - "Behavior of the API in the absence of an installed SDK": the API
+///   returns a non-recording span carrying the `SpanContext` from the
+///   parent `Context` unchanged, or an empty one (all-zero IDs, empty
+///   `TraceState`, unsampled `TraceFlags`) when the context has no span.
+///
+/// Unlike other spans, a [NonRecordingSpan] may carry an invalid
+/// (all-zero) [SpanContext].
+class NonRecordingSpan extends APISpan {
+  /// Wraps [spanContext] in a non-recording span.
+  ///
+  /// Also available as `OTelAPI.nonRecordingSpan`. [OTelAPI.initialize]
+  /// must have been called first.
+  factory NonRecordingSpan(SpanContext spanContext) {
+    if (OTelFactory.otelFactory == null) {
+      throw StateError('Call initialize() first.');
+    }
+    return NonRecordingSpan._(
+      spanContext: spanContext,
+      instrumentationScope:
+          InstrumentationScopeCreate.create(name: 'noop-tracer'),
+      attributes: OTelFactory.otelFactory!.attributes(),
+    );
+  }
+
+  NonRecordingSpan._({
+    required super.spanContext,
+    required super.instrumentationScope,
+    required super.attributes,
+  }) : super._(name: '');
+
+  /// Always `false`: this span never records, per the spec.
+  @override
+  bool get isRecording => false;
+
+  /// Never modifiable: every mutating operation is a no-op, per the
+  /// spec ("all other operations MUST be no-op").
+  @override
+  bool get _modifiable => false;
+}

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -15,6 +15,7 @@ import 'span_id.dart';
 import 'span_kind.dart';
 import 'span_link.dart';
 
+part 'non_recording_span.dart';
 part 'span_create.dart';
 
 /// The set of canonical status codes.
@@ -119,6 +120,11 @@ class APISpan {
   /// Returns whether this span has been ended
   bool get isEnded => _endTime != null;
 
+  /// Whether mutating operations currently apply. The default is
+  /// "until the span ends"; [NonRecordingSpan] overrides this to make
+  /// every mutation a no-op, per the spec.
+  bool get _modifiable => !isEnded;
+
   /// The status of this [APISpan].
   SpanStatusCode get status => _spanStatusCode ?? SpanStatusCode.Unset;
 
@@ -169,7 +175,7 @@ class APISpan {
   /// present during span creation.
   /// Ignored if isEnded
   set attributes(Attributes newAttributes) {
-    if (!isEnded) {
+    if (_modifiable) {
       _attributes = newAttributes;
     }
   }
@@ -180,7 +186,7 @@ class APISpan {
   /// present during span creation.
   /// Ignored if isEnded
   void setStringAttribute<T>(String name, String value) {
-    if (!isEnded) {
+    if (_modifiable) {
       _attributes = _attributes.copyWithStringAttribute(name, value);
     }
   }
@@ -191,7 +197,7 @@ class APISpan {
   /// present during span creation.
   /// Ignored if isEnded
   void setBoolAttribute(String name, bool value) {
-    if (!isEnded) {
+    if (_modifiable) {
       _attributes = _attributes.copyWithBoolAttribute(name, value);
     }
   }
@@ -202,7 +208,7 @@ class APISpan {
   /// present during span creation.
   /// Ignored if isEnded
   void setIntAttribute(String name, int value) {
-    if (!isEnded) {
+    if (_modifiable) {
       _attributes = _attributes.copyWithIntAttribute(name, value);
     }
   }
@@ -213,7 +219,7 @@ class APISpan {
   /// present during span creation.
   /// Ignored if isEnded
   void setDoubleAttribute(String name, double value) {
-    if (!isEnded) {
+    if (_modifiable) {
       _attributes = _attributes.copyWithDoubleAttribute(name, value);
     }
   }
@@ -225,7 +231,7 @@ class APISpan {
   /// present during span creation.
   /// Ignored if isEnded
   void setDateTimeAsStringAttribute(String name, DateTime value) {
-    if (!isEnded) {
+    if (_modifiable) {
       _attributes = _attributes.copyWithStringAttribute(
           name, Timestamp.dateTimeToString(value));
     }
@@ -237,7 +243,7 @@ class APISpan {
   /// present during span creation.
   /// Ignored if isEnded
   void setStringListAttribute<T>(String name, List<String> value) {
-    if (!isEnded) {
+    if (_modifiable) {
       _attributes = _attributes.copyWithStringListAttribute(name, value);
     }
   }
@@ -248,7 +254,7 @@ class APISpan {
   /// present during span creation.
   /// Ignored if isEnded
   void setBoolListAttribute(String name, List<bool> value) {
-    if (!isEnded) {
+    if (_modifiable) {
       _attributes = _attributes.copyWithBoolListAttribute(name, value);
     }
   }
@@ -259,7 +265,7 @@ class APISpan {
   /// present during span creation.
   /// Ignored if isEnded
   void setIntListAttribute(String name, List<int> value) {
-    if (!isEnded) {
+    if (_modifiable) {
       _attributes = _attributes.copyWithIntListAttribute(name, value);
     }
   }
@@ -270,7 +276,7 @@ class APISpan {
   /// present during span creation.
   /// Ignored if isEnded
   void setDoubleListAttribute(String name, List<double> value) {
-    if (!isEnded) {
+    if (_modifiable) {
       _attributes = _attributes.copyWithDoubleListAttribute(name, value);
     }
   }
@@ -280,7 +286,7 @@ class APISpan {
   /// "standard event names and keys" which have prescribed semantic meanings.
   /// See https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md
   void addEvent(SpanEvent spanEvent) {
-    if (!isEnded) {
+    if (_modifiable) {
       _spanEvents ??= [];
       _spanEvents!.add(spanEvent);
     }
@@ -291,7 +297,7 @@ class APISpan {
     if (OTelFactory.otelFactory == null) {
       throw StateError('Call initialize() first.');
     }
-    if (!isEnded) {
+    if (_modifiable) {
       _spanEvents ??= [];
       // Source the event timestamp from this span's TimeProvider so events
       // share the same clock as start/end. Bypasses the static
@@ -308,7 +314,7 @@ class APISpan {
     if (OTelFactory.otelFactory == null) {
       throw StateError('Call initialize() first.');
     }
-    if (!isEnded) {
+    if (_modifiable) {
       _spanEvents ??= [];
       spanEvents.forEach((name, attributes) => _spanEvents!.add(OTelFactory
           .otelFactory!
@@ -323,7 +329,7 @@ class APISpan {
     if (OTelFactory.otelFactory == null) {
       throw StateError('Call initialize() first.');
     }
-    if (!isEnded) {
+    if (_modifiable) {
       _spanLinks ??= [];
       _spanLinks!.add(OTelFactory.otelFactory!
           .spanLink(spanContext, attributes: attributes));
@@ -333,7 +339,7 @@ class APISpan {
   /// Adds a link to this Span.
   /// Ignored if the span is ended.
   void addSpanLink(SpanLink spanLink) {
-    if (!isEnded) {
+    if (_modifiable) {
       _spanLinks ??= [];
       _spanLinks!.add(spanLink);
     }
@@ -348,7 +354,7 @@ class APISpan {
   /// [description] When [statusCode] is error, description should include the
   /// error's toString() if an exception is caught available.
   void setStatus(SpanStatusCode statusCode, [String? description]) {
-    if (!isEnded) {
+    if (_modifiable) {
       if (statusCode == SpanStatusCode.Unset) {
         return;
       }
@@ -372,7 +378,7 @@ class APISpan {
   ///
   /// If the span has already ended this is ignored.
   void updateName(String name) {
-    if (!isEnded) {
+    if (_modifiable) {
       _name = name;
     }
   }
@@ -428,7 +434,7 @@ class APISpan {
   ///
   /// Only the first call to end modifies the Span.
   void end({DateTime? endTime, SpanStatusCode? spanStatus}) {
-    if (!isEnded) {
+    if (_modifiable) {
       _endTime = endTime ?? _timeProvider.nowDateTime();
       // Only set status if no status has been set
       if (_spanStatusCode == null || _spanStatusCode == SpanStatusCode.Unset) {
@@ -447,7 +453,7 @@ class APISpan {
   /// @param attributes The attributes to add to this span
   /// @return void
   void addAttributes(Attributes attributes) {
-    if (!isEnded) {
+    if (_modifiable) {
       _attributes = _attributes.copyWithAttributes(attributes);
     }
   }

--- a/lib/src/api/trace/tracer.dart
+++ b/lib/src/api/trace/tracer.dart
@@ -151,6 +151,21 @@ class APITracer {
     final contextSpan = contextOfSpan.span;
     final effectiveParentSpan = parentSpan ?? contextSpan;
 
+    // trace/api.md, "Behavior of the API in the absence of an installed
+    // SDK": with only the API installed, return a non-recording span
+    // carrying the SpanContext from the parent context (explicit or
+    // implicit) unchanged — no new IDs are minted — or an empty one
+    // (all-zero IDs, unsampled) when the context has no span. The SDK
+    // delegates span creation here with its own factory installed, so
+    // this branch only applies when no SDK is present.
+    if (OTelFactory.otelFactory!.isAPIFactory) {
+      final parentSpanContext = spanContext ??
+          effectiveParentSpan?.spanContext ??
+          contextOfSpan.spanContext;
+      return NonRecordingSpan(
+          parentSpanContext ?? OTelFactory.otelFactory!.spanContextInvalid());
+    }
+
     // If spanContext is not provided, we need to create one
     SpanContext effectiveSpanContext;
     if (spanContext != null) {

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:dartastic_opentelemetry_api/src/api/factory/otel_api_factory.dart';
+import 'package:dartastic_opentelemetry_api/src/factory/otel_factory.dart';
 import 'package:test/expect.dart';
 
 class IsBetween extends Matcher {
@@ -18,4 +20,33 @@ class IsBetween extends Matcher {
   @override
   Description describe(Description description) =>
       description.add('is between $before and $after');
+}
+
+/// An [OTelAPIFactory] that reports `isAPIFactory == false`, mimicking an
+/// installed SDK. The API's spec-mandated no-SDK behavior (non-recording
+/// spans carrying the parent SpanContext, all-zero IDs for roots) only
+/// applies when the installed factory is the pure API factory, so tests
+/// that exercise the real span-creation engine (ID minting, parent/child
+/// validation, attribute recording) install this instead.
+class SdkLikeFactory extends OTelAPIFactory {
+  /// Creates the SDK-like factory with the standard test configuration.
+  SdkLikeFactory({
+    required super.apiEndpoint,
+    required super.apiServiceName,
+    required super.apiServiceVersion,
+  });
+
+  @override
+  bool get isAPIFactory => false;
+}
+
+/// Replaces the installed factory with an [SdkLikeFactory], so span
+/// creation behaves as it does with an SDK installed. Call after
+/// `OTelAPI.initialize()`.
+void installSdkLikeFactory() {
+  OTelFactory.otelFactory = SdkLikeFactory(
+    apiEndpoint: 'http://localhost:4317',
+    apiServiceName: 'test-service',
+    apiServiceVersion: '1.0.0',
+  );
 }

--- a/test/unit/api/context/context_test.dart
+++ b/test/unit/api/context/context_test.dart
@@ -4,6 +4,8 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
+import '../../../test_util.dart';
+
 void main() {
   group('Context', () {
     setUp(() {
@@ -13,6 +15,7 @@ void main() {
         serviceName: 'test-service',
         serviceVersion: '1.0.0',
       );
+      installSdkLikeFactory();
     });
 
     test('uses root context by default', () {

--- a/test/unit/api/trace/no_sdk_span_behavior_test.dart
+++ b/test/unit/api/trace/no_sdk_span_behavior_test.dart
@@ -25,9 +25,7 @@ void main() {
     );
   });
 
-  group('no-SDK span behavior (trace/api.md)',
-      skip: 'Known spec violation — fix needs a design decision because the '
-          'SDK delegates span creation to APITracer; see #40', () {
+  group('no-SDK span behavior (trace/api.md)', () {
     test('parentless span has all-zero IDs and unsampled flags', () {
       final span = OTelAPI.tracerProvider().getTracer('test').startSpan('root');
       expect(span.spanContext.isValid, isFalse);
@@ -51,6 +49,51 @@ void main() {
           .startSpan('child', context: context);
       expect(span.spanContext.traceId, equals(parent.traceId));
       expect(span.spanContext.spanId, equals(parent.spanId));
+    });
+
+    test('all operations on a no-SDK span are no-ops', () {
+      final span = OTelAPI.tracerProvider().getTracer('test').startSpan('op');
+      span.setStringAttribute<String>('k', 'v');
+      span.addEventNow('event');
+      span.setStatus(SpanStatusCode.Error, 'boom');
+      span.updateName('renamed');
+      span.end();
+      expect(span.attributes.toList(), isEmpty);
+      expect(span.spanEvents, isNull);
+      expect(span.status, equals(SpanStatusCode.Unset));
+      expect(span.name, equals(''));
+      expect(span.isEnded, isFalse);
+      expect(span.isRecording, isFalse);
+    });
+  });
+
+  // trace/api.md, "Wrapping a SpanContext in a Span": "The API MUST provide
+  // an operation for wrapping a SpanContext with an object implementing the
+  // Span interface [...] SHOULD be named NonRecordingSpan." GetContext
+  // returns the wrapped context, IsRecording returns false, everything
+  // else is a no-op.
+  group('NonRecordingSpan (trace/api.md SpanContext wrapping)', () {
+    test('wraps a SpanContext, returning it unchanged', () {
+      final wrapped = OTelAPI.spanContext(
+        traceId: OTelAPI.traceIdFrom('0123456789abcdef0123456789abcdef'),
+        spanId: OTelAPI.spanIdFrom('0123456789abcdef'),
+      );
+      final span = OTelAPI.nonRecordingSpan(wrapped);
+      expect(span, isA<NonRecordingSpan>());
+      expect(span.spanContext, same(wrapped));
+      expect(span.isRecording, isFalse);
+    });
+
+    test('mutating operations are no-ops', () {
+      final span = OTelAPI.nonRecordingSpan(OTelAPI.spanContextInvalid());
+      span.setBoolAttribute('flag', true);
+      span.addEventNow('event');
+      span.setStatus(SpanStatusCode.Ok);
+      span.end();
+      expect(span.attributes.toList(), isEmpty);
+      expect(span.spanEvents, isNull);
+      expect(span.status, equals(SpanStatusCode.Unset));
+      expect(span.isEnded, isFalse);
     });
   });
 }

--- a/test/unit/api/trace/span_coverage_test.dart
+++ b/test/unit/api/trace/span_coverage_test.dart
@@ -4,6 +4,8 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
+import '../../../test_util.dart';
+
 void main() {
   group('APISpan - Additional Coverage Tests', () {
     late OTelFactory originalFactory;
@@ -16,6 +18,7 @@ void main() {
         serviceName: 'test-service',
         serviceVersion: '1.0.0',
       );
+      installSdkLikeFactory();
 
       // Store the original factory
       originalFactory = OTelFactory.otelFactory!;

--- a/test/unit/api/trace/span_exception_test.dart
+++ b/test/unit/api/trace/span_exception_test.dart
@@ -8,6 +8,8 @@ import 'package:dartastic_opentelemetry_api/src/api/trace/tracer.dart';
 import 'package:dartastic_opentelemetry_api/src/api/trace/tracer_provider.dart';
 import 'package:test/test.dart';
 
+import '../../../test_util.dart';
+
 void main() {
   group('Span Exception Handling', () {
     late APITracerProvider tracerProvider;
@@ -21,6 +23,7 @@ void main() {
         serviceName: 'test-service',
         serviceVersion: '1.0.0',
       );
+      installSdkLikeFactory();
 
       tracerProvider = OTelAPI.tracerProvider();
       tracer = tracerProvider.getTracer('test-tracer');

--- a/test/unit/api/trace/span_link_test.dart
+++ b/test/unit/api/trace/span_link_test.dart
@@ -4,6 +4,8 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
+import '../../../test_util.dart';
+
 void main() {
   group('Span Links and Status', () {
     late APITracerProvider tracerProvider;
@@ -16,6 +18,7 @@ void main() {
         serviceName: 'test-service',
         serviceVersion: '1.0.0',
       );
+      installSdkLikeFactory();
 
       tracerProvider = OTelAPI.tracerProvider();
       // Use proper method signature

--- a/test/unit/api/trace/span_test.dart
+++ b/test/unit/api/trace/span_test.dart
@@ -23,6 +23,7 @@ void main() {
         serviceName: 'test-service',
         serviceVersion: '1.0.0',
       );
+      installSdkLikeFactory();
 
       fullyTypesMapOfKVs = {
         'str': 'value',

--- a/test/unit/api/trace/trace_span_test.dart
+++ b/test/unit/api/trace/trace_span_test.dart
@@ -4,6 +4,8 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
+import '../../../test_util.dart';
+
 void main() {
   late APITracerProvider tracerProvider;
 
@@ -14,6 +16,7 @@ void main() {
       serviceName: 'test-service',
       serviceVersion: '1.0.0',
     );
+    installSdkLikeFactory();
     tracerProvider = OTelAPI.tracerProvider();
   });
 

--- a/test/unit/api/trace/tracer_coverage_test.dart
+++ b/test/unit/api/trace/tracer_coverage_test.dart
@@ -4,6 +4,8 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
+import '../../../test_util.dart';
+
 void main() {
   group('APITracer - Additional Coverage Tests', () {
     late OTelFactory originalFactory;
@@ -15,6 +17,7 @@ void main() {
         serviceName: 'test-service',
         serviceVersion: '1.0.0',
       );
+      installSdkLikeFactory();
 
       // Store the original factory
       originalFactory = OTelFactory.otelFactory!;

--- a/test/unit/api/trace/tracer_test.dart
+++ b/test/unit/api/trace/tracer_test.dart
@@ -4,6 +4,8 @@
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
+import '../../../test_util.dart';
+
 void main() {
   group('APITracer', () {
     late OTelFactory originalFactory;
@@ -15,6 +17,7 @@ void main() {
         serviceName: 'test-service',
         serviceVersion: '1.0.0',
       );
+      installSdkLikeFactory();
 
       // Store the original factory
       originalFactory = OTelFactory.otelFactory!;


### PR DESCRIPTION
Fixes #40

Implements trace/api.md, "Behavior of the API in the absence of an installed SDK" and "Wrapping a SpanContext in a Span":

- **"The API MUST return a non-recording Span with the SpanContext in the parent Context (whether explicitly given or implicit current)."** — `startSpan`/`createSpan` under the pure API factory now return the parent's `SpanContext` unchanged; no new IDs are minted.
- **"If the parent Context contains no Span, an empty non-recording Span MUST be returned instead"** — parentless spans carry an all-zero `SpanContext` with unsampled flags.
- **"The API MUST provide an operation for wrapping a SpanContext [...] SHOULD be named NonRecordingSpan."** — new `NonRecordingSpan` + `OTelAPI.nonRecordingSpan(SpanContext)`: `spanContext` returns the wrapped context unchanged, `isRecording` is `false`, every other operation is a no-op.

**Design (per the issue's constraint):** the no-op branch is gated on `OTelFactory.otelFactory!.isAPIFactory`, so the SDK's delegation of span creation to `APITracer` (its ID-minting engine) is untouched — SDK spans behave exactly as before. Span mutation guards are centralized in a private `_modifiable` getter (`!isEnded` by default) that `NonRecordingSpan` overrides to `false`, so every current and future mutator no-ops in one place.

**Tests:** builds on #41 — its pinned red contracts are unskipped and extended (no-op mutations, wrapper operation). The ~54 span/tracer/context tests that exercise the real engine now install a test `SdkLikeFactory` (`isAPIFactory == false`), which is honest about what they test: recording spans only exist under an SDK. #41 can be closed as superseded when this merges.

**Breaking:** API-only consumers that relied on random valid IDs / recording spans pre-SDK will see spec behavior instead (CHANGELOG entry included). SDK consumers unaffected.

Verification: `dart analyze --fatal-infos` clean, 759 VM tests green, touched test dirs green on chrome under dart2js + dart2wasm, format clean, pre-push coverage gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)