### PR TITLE
feat: global TextMapPropagator with no-op default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   spec's "Wrapping a SpanContext in a Span" operation: the wrapped
   context is returned unchanged, `isRecording` is `false`, and all other
   operations are no-ops (#40).
+- **Global `TextMapPropagator`** — `OTelAPI.textMapPropagator` getter/setter,
+  implementing the spec's Global Propagators requirement: "The OpenTelemetry
+  API MUST provide a way to obtain a propagator for each supported Propagator
+  type" (`TextMapPropagator` being the single supported type today). The
+  global is non-generic (`TextMapPropagator<dynamic, dynamic>`) and, like
+  every other API object, routed through `OTelFactory`, so a replacement
+  factory can substitute its own implementation. Isolate-local;
+  `OTelAPI.reset()` restores the no-op default (#42).
+- `OTelAPI.compositePropagator` / `OTelFactory.compositePropagator` —
+  factory-routed construction for `CompositePropagator`, previously the
+  only instantiable API object built by direct construction; its public
+  constructor is now private (**Breaking**, construct via the factory)
+  (#42).
+- **`NoopTextMapPropagator`** — the default value of the global, satisfying
+  "The OpenTelemetry API MUST use no-op propagators unless explicitly
+  configured otherwise": `inject` writes nothing and `extract` returns the
+  passed `Context` unchanged (#42).
 
 ### Deprecated
 

--- a/lib/dartastic_opentelemetry_api.dart
+++ b/lib/dartastic_opentelemetry_api.dart
@@ -24,6 +24,7 @@ export 'src/api/context/context.dart';
 export 'src/api/context/context_key.dart';
 export 'src/api/context/propagation/composite_propagator.dart';
 export 'src/api/context/propagation/context_propagator.dart';
+export 'src/api/context/propagation/noop_text_map_propagator.dart';
 export 'src/api/context/propagation/text_map_propagator.dart';
 export 'src/api/factory/otel_api_factory.dart';
 // Id

--- a/lib/src/api/context/propagation/composite_propagator.dart
+++ b/lib/src/api/context/propagation/composite_propagator.dart
@@ -4,13 +4,15 @@
 import '../context.dart';
 import 'text_map_propagator.dart';
 
-/// A propagator that combines multiple other propagators
+/// A propagator that combines multiple other propagators.
+///
+/// Created via `OTelAPI.compositePropagator` (or an `OTelFactory`
+/// implementation), like every other API object. The propagators are
+/// applied in order for injection and in reverse order for extraction.
 class CompositePropagator<C, V> implements TextMapPropagator<C, V> {
   final List<TextMapPropagator<C, V>> _propagators;
 
-  /// Creates a new CompositePropagator with the given list of propagators.
-  /// The propagators are applied in order for injection and in reverse order for extraction.
-  CompositePropagator(List<TextMapPropagator<C, V>> propagators)
+  CompositePropagator._(List<TextMapPropagator<C, V>> propagators)
       : _propagators = List.unmodifiable(propagators);
 
   @override
@@ -38,4 +40,14 @@ class CompositePropagator<C, V> implements TextMapPropagator<C, V> {
     }
     return set.toList(growable: false);
   }
+}
+
+/// Internal constructor access for [CompositePropagator].
+/// Used by `OTelFactory` implementations; users should create composite
+/// propagators with `OTelAPI.compositePropagator`.
+class CompositePropagatorCreate {
+  /// Creates a [CompositePropagator] delegating to [propagators].
+  static CompositePropagator<C, V> create<C, V>(
+          List<TextMapPropagator<C, V>> propagators) =>
+      CompositePropagator<C, V>._(propagators);
 }

--- a/lib/src/api/context/propagation/noop_text_map_propagator.dart
+++ b/lib/src/api/context/propagation/noop_text_map_propagator.dart
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import '../context.dart';
+import 'text_map_propagator.dart';
+
+/// A [TextMapPropagator] that propagates nothing.
+///
+/// The OpenTelemetry specification (api-propagators.md, "Global Propagators")
+/// requires that "The OpenTelemetry API MUST use no-op propagators unless
+/// explicitly configured otherwise." This class is that no-op:
+/// [inject] writes nothing to the carrier and [extract] returns the passed
+/// [Context] unchanged.
+///
+/// A `NoopTextMapPropagator<dynamic, dynamic>` is the default value of the
+/// global [OTelAPI.textMapPropagator].
+class NoopTextMapPropagator<C, V> implements TextMapPropagator<C, V> {
+  /// Creates a no-op propagator.
+  const NoopTextMapPropagator();
+
+  /// Returns an empty list; a no-op propagator sets no carrier fields.
+  @override
+  List<String> fields() => const <String>[];
+
+  /// Does nothing; the carrier is left untouched.
+  @override
+  void inject(Context context, C carrier, TextMapSetter<V> setter) {}
+
+  /// Returns [context] unchanged; nothing is read from the carrier.
+  @override
+  Context extract(Context context, C carrier, TextMapGetter<V> getter) =>
+      context;
+}

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -14,6 +14,8 @@ import 'common/attributes.dart';
 import 'common/instrumentation_scope.dart';
 import 'context/context.dart';
 import 'context/context_key.dart';
+import 'context/propagation/noop_text_map_propagator.dart';
+import 'context/propagation/text_map_propagator.dart';
 import 'factory/otel_api_factory.dart';
 import 'id/id_generator.dart';
 import 'logs/logger.dart';
@@ -137,6 +139,49 @@ class OTelAPI {
   static Context context({Baggage? baggage}) {
     _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.context(baggage: baggage);
+  }
+
+  /// The global [TextMapPropagator].
+  ///
+  /// The OpenTelemetry specification (api-propagators.md, "Global
+  /// Propagators") requires that "The OpenTelemetry API MUST provide a way
+  /// to obtain a propagator for each supported Propagator type" via global
+  /// Get/Set methods; this getter/setter pair satisfies that requirement
+  /// for [TextMapPropagator], the single supported Propagator type today.
+  ///
+  /// Per the same section, "The OpenTelemetry API MUST use no-op propagators
+  /// unless explicitly configured otherwise", so this defaults to a
+  /// [NoopTextMapPropagator] until an SDK (or application) sets it.
+  ///
+  /// The global is deliberately non-generic
+  /// (`TextMapPropagator<dynamic, dynamic>`) so a single global can serve
+  /// carriers of any type; propagator implementations remain generic and
+  /// type-safe at their definition sites.
+  ///
+  /// Like every other API object, the global propagator goes through
+  /// [OTelFactory], so a replacement factory can substitute its own
+  /// implementation. It is process/isolate-local: setting it in one
+  /// isolate does not propagate to other isolates.
+  static TextMapPropagator<dynamic, dynamic> get textMapPropagator {
+    _getAndCacheOtelFactory();
+    return OTelFactory.otelFactory!.textMapPropagator;
+  }
+
+  /// Sets the global [TextMapPropagator], replacing the previous one.
+  ///
+  /// Typically called by an SDK during initialization; instrumentation
+  /// libraries should only read the global via [textMapPropagator].
+  static set textMapPropagator(TextMapPropagator<dynamic, dynamic> propagator) {
+    _getAndCacheOtelFactory();
+    OTelFactory.otelFactory!.textMapPropagator = propagator;
+  }
+
+  /// Creates a [TextMapPropagator] that delegates to [propagators],
+  /// injecting in list order and extracting in reverse order.
+  static TextMapPropagator<C, V> compositePropagator<C, V>(
+      List<TextMapPropagator<C, V>> propagators) {
+    _getAndCacheOtelFactory();
+    return OTelFactory.otelFactory!.compositePropagator<C, V>(propagators);
   }
 
   /// Creates a new InstrumentationScope.

--- a/lib/src/factory/otel_factory.dart
+++ b/lib/src/factory/otel_factory.dart
@@ -10,6 +10,9 @@ import '../api/common/attributes.dart';
 import '../api/common/instrumentation_scope.dart';
 import '../api/context/context.dart';
 import '../api/context/context_key.dart';
+import '../api/context/propagation/composite_propagator.dart';
+import '../api/context/propagation/noop_text_map_propagator.dart';
+import '../api/context/propagation/text_map_propagator.dart';
 import '../api/factory/otel_api_factory.dart';
 import '../api/logs/logger_provider.dart';
 import '../api/metrics/counter.dart';
@@ -31,6 +34,7 @@ import '../api/trace/trace_flags.dart';
 import '../api/trace/trace_id.dart';
 import '../api/trace/trace_state.dart';
 import '../api/trace/tracer_provider.dart';
+import '../util/otel_log.dart';
 
 /// A function that creates the OTel Factory, used bu initialize methods
 typedef OTelFactoryCreationFunction = OTelFactory Function(
@@ -455,6 +459,40 @@ abstract class OTelFactory {
   ///
   /// This clears all cached providers and resets the factory configuration to defaults.
   /// This method is primarily used for testing purposes.
+  TextMapPropagator<dynamic, dynamic>? _textMapPropagator;
+
+  /// Creates a [TextMapPropagator] that delegates to [propagators],
+  /// injecting in list order and extracting in reverse order.
+  TextMapPropagator<C, V> compositePropagator<C, V>(
+          List<TextMapPropagator<C, V>> propagators) =>
+      CompositePropagatorCreate.create<C, V>(propagators);
+
+  /// The global [TextMapPropagator].
+  ///
+  /// The OpenTelemetry specification (api-propagators.md, "Global
+  /// Propagators") requires that "The OpenTelemetry API MUST provide a way
+  /// to obtain a propagator for each supported Propagator type" via global
+  /// Get/Set methods, and that "The OpenTelemetry API MUST use no-op
+  /// propagators unless explicitly configured otherwise" — so this defaults
+  /// to a [NoopTextMapPropagator] until an SDK (or application) sets it.
+  ///
+  /// The global lives on the factory so that, like every other API
+  /// object, a replacement factory can substitute its own implementation.
+  TextMapPropagator<dynamic, dynamic> get textMapPropagator =>
+      _textMapPropagator ??= const NoopTextMapPropagator<dynamic, dynamic>();
+
+  /// Installs [propagator] as the global [TextMapPropagator], replacing
+  /// the previous one. Typically called by an SDK during initialization;
+  /// instrumentation libraries should only read the global.
+  set textMapPropagator(TextMapPropagator<dynamic, dynamic> propagator) {
+    if (OTelLog.isDebug()) {
+      OTelLog.debug('OTelFactory: replacing the global TextMapPropagator '
+          '(${textMapPropagator.runtimeType}) with '
+          '${propagator.runtimeType}.');
+    }
+    _textMapPropagator = propagator;
+  }
+
   void reset() {
     _apiEndpoint = defaultEndpoint;
     _apiServiceName = OTelAPI.defaultServiceName;
@@ -465,6 +503,7 @@ abstract class OTelFactory {
     _tracerProviders = null;
     _meterProviders?.clear();
     _meterProviders = null;
+    _textMapPropagator = null;
     otelFactory = null;
   }
 

--- a/test/unit/api/context/propagation/composite_propagator_test.dart
+++ b/test/unit/api/context/propagation/composite_propagator_test.dart
@@ -76,6 +76,15 @@ void main() {
   });
 
   group('CompositePropagator', () {
+    test('OTelAPI.compositePropagator creates via the factory', () {
+      final propagator1 = MockPropagator('p1', ['f1']);
+      final propagator2 = MockPropagator('p2', ['f2']);
+      final composite =
+          OTelAPI.compositePropagator<Map<String, String>, String>(
+              [propagator1, propagator2]);
+      expect(composite.fields(), containsAll(['f1', 'f2']));
+    });
+
     test(
         'fields() returns the combined fields from all propagators without duplicates',
         () {

--- a/test/unit/api/context/propagation/composite_propagator_test.dart
+++ b/test/unit/api/context/propagation/composite_propagator_test.dart
@@ -84,7 +84,8 @@ void main() {
       final propagator3 = MockPropagator('p3', ['field3', 'field4']);
 
       final composite =
-          CompositePropagator([propagator1, propagator2, propagator3]);
+          OTelAPI.compositePropagator<Map<String, String>, String>(
+              [propagator1, propagator2, propagator3]);
 
       final fields = composite.fields();
       expect(fields, containsAll(['field1', 'field2', 'field3', 'field4']));
@@ -97,7 +98,8 @@ void main() {
       final propagator3 = MockPropagator('p3', ['field3']);
 
       final composite =
-          CompositePropagator([propagator1, propagator2, propagator3]);
+          OTelAPI.compositePropagator<Map<String, String>, String>(
+              [propagator1, propagator2, propagator3]);
 
       final context = OTelAPI.context();
       final carrier = {
@@ -119,7 +121,9 @@ void main() {
       final propagator1 = MockPropagator('p1', ['field1', 'missing1']);
       final propagator2 = MockPropagator('p2', ['field2', 'missing2']);
 
-      final composite = CompositePropagator([propagator1, propagator2]);
+      final composite =
+          OTelAPI.compositePropagator<Map<String, String>, String>(
+              [propagator1, propagator2]);
 
       // Create context with existing baggage
       final baggage = OTelAPI.baggage().copyWith('existing', 'value');
@@ -148,7 +152,8 @@ void main() {
       final propagator3 = MockPropagator('p3', ['field3']);
 
       final composite =
-          CompositePropagator([propagator1, propagator2, propagator3]);
+          OTelAPI.compositePropagator<Map<String, String>, String>(
+              [propagator1, propagator2, propagator3]);
 
       // Create context with baggage values that match each propagator's prefix
       final baggage = OTelAPI.baggage()
@@ -173,7 +178,9 @@ void main() {
       final propagator1 = MockPropagator('p1', ['field1']);
       final propagator2 = MockPropagator('p2', ['field2']);
 
-      final composite = CompositePropagator([propagator1, propagator2]);
+      final composite =
+          OTelAPI.compositePropagator<Map<String, String>, String>(
+              [propagator1, propagator2]);
 
       // Create context with values that don't match propagator prefixes
       final baggage = OTelAPI.baggage()
@@ -194,7 +201,8 @@ void main() {
     });
 
     test('works with empty list of propagators', () {
-      final composite = CompositePropagator<Map<String, String>, String>([]);
+      final composite =
+          OTelAPI.compositePropagator<Map<String, String>, String>([]);
 
       final context = OTelAPI.context();
       final carrier = <String, String>{};

--- a/test/unit/api/context/propagation/global_propagator_test.dart
+++ b/test/unit/api/context/propagation/global_propagator_test.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
 // Spec-compliance test for context/api-propagators.md, "Global Propagators":
@@ -9,12 +10,155 @@ import 'package:test/test.dart';
 //   each supported Propagator type" — with Get/Set global methods.
 // - "The OpenTelemetry API MUST use no-op propagators unless explicitly
 //   configured otherwise."
+
+// Minimal test double reading from a Map<String, String> carrier.
+class MapTextMapGetter implements TextMapGetter<String> {
+  final Map<String, String> _values;
+
+  MapTextMapGetter(this._values);
+
+  @override
+  String? get(String key) => _values[key];
+
+  @override
+  Iterable<String> keys() => _values.keys;
+}
+
+// Minimal test double writing to a Map<String, String> carrier.
+class MapTextMapSetter implements TextMapSetter<String> {
+  final Map<String, String> _values;
+
+  MapTextMapSetter(this._values);
+
+  @override
+  void set(String key, String value) {
+    _values[key] = value;
+  }
+}
+
+// A distinguishable propagator to install as the global.
+class MarkerPropagator implements TextMapPropagator<dynamic, dynamic> {
+  static const String field = 'x-marker';
+
+  @override
+  List<String> fields() => const [field];
+
+  @override
+  void inject(Context context, dynamic carrier, TextMapSetter<dynamic> setter) {
+    setter.set(field, 'marked');
+  }
+
+  @override
+  Context extract(
+          Context context, dynamic carrier, TextMapGetter<dynamic> getter) =>
+      context;
+}
+
+// A replacement factory that substitutes its own default global
+// propagator — the factory is the substitution seam for every API
+// object, the global propagator included.
+class MarkerDefaultFactory extends OTelAPIFactory {
+  MarkerDefaultFactory({
+    required super.apiEndpoint,
+    required super.apiServiceName,
+    required super.apiServiceVersion,
+  });
+
+  @override
+  TextMapPropagator<dynamic, dynamic> get textMapPropagator =>
+      MarkerPropagator();
+}
+
 void main() {
-  test('the API provides a global TextMapPropagator with a no-op default',
-      skip: 'Not implemented; needs a design decision on generic vs '
-          'non-generic global surface — see #42', () {
-    fail('No global propagator accessor or no-op TextMapPropagator exists '
-        'in the API; instrumentation libraries cannot obtain "the" '
-        'propagator as the spec requires.');
+  setUp(() {
+    OTelAPI.reset();
+    OTelAPI.initialize(
+      endpoint: 'http://localhost:4317',
+      serviceName: 'test-service',
+      serviceVersion: '1.0.0',
+    );
+  });
+
+  group('Global TextMapPropagator', () {
+    test('the default global propagator is a no-op TextMapPropagator', () {
+      final propagator = OTelAPI.textMapPropagator;
+      expect(propagator, isA<TextMapPropagator<dynamic, dynamic>>());
+      expect(propagator, isA<NoopTextMapPropagator<dynamic, dynamic>>());
+      expect(propagator.fields(), isEmpty);
+    });
+
+    test('the no-op extract returns the identical context unchanged', () {
+      final context = OTelAPI.context();
+      final carrier = {'traceparent': '00-abc-def-01'};
+
+      final extracted = OTelAPI.textMapPropagator
+          .extract(context, carrier, MapTextMapGetter(carrier));
+
+      expect(extracted, same(context));
+    });
+
+    test('the no-op inject writes nothing to the carrier', () {
+      final context = OTelAPI.context();
+      final carrier = <String, String>{};
+
+      OTelAPI.textMapPropagator
+          .inject(context, carrier, MapTextMapSetter(carrier));
+
+      expect(carrier, isEmpty);
+    });
+
+    test('set replaces the global propagator and get returns it', () {
+      final custom = MarkerPropagator();
+
+      OTelAPI.textMapPropagator = custom;
+
+      expect(OTelAPI.textMapPropagator, same(custom));
+
+      // The installed propagator is the one instrumentation obtains and uses.
+      final carrier = <String, String>{};
+      OTelAPI.textMapPropagator
+          .inject(OTelAPI.context(), carrier, MapTextMapSetter(carrier));
+      expect(carrier, equals({MarkerPropagator.field: 'marked'}));
+    });
+
+    test('OTelAPI.reset() restores the no-op default', () {
+      final custom = MarkerPropagator();
+      OTelAPI.textMapPropagator = custom;
+      expect(OTelAPI.textMapPropagator, same(custom));
+
+      OTelAPI.reset();
+
+      final propagator = OTelAPI.textMapPropagator;
+      expect(propagator, isNot(same(custom)));
+      expect(propagator, isA<NoopTextMapPropagator<dynamic, dynamic>>());
+    });
+
+    test('a replacement factory substitutes its own global propagator', () {
+      OTelFactory.otelFactory = MarkerDefaultFactory(
+        apiEndpoint: 'http://localhost:4317',
+        apiServiceName: 'test-service',
+        apiServiceVersion: '1.0.0',
+      );
+      expect(OTelAPI.textMapPropagator, isA<MarkerPropagator>());
+    });
+
+    test('setting the global propagator logs at debug level when enabled', () {
+      final logged = <String>[];
+      final priorLogFunction = OTelLog.logFunction;
+      final priorLevel = OTelLog.currentLevel;
+      OTelLog.logFunction = logged.add;
+      OTelLog.currentLevel = LogLevel.debug;
+      addTearDown(() {
+        OTelLog.logFunction = priorLogFunction;
+        OTelLog.currentLevel = priorLevel;
+      });
+
+      OTelAPI.textMapPropagator = MarkerPropagator();
+
+      expect(
+        logged.join('\n'),
+        allOf(contains('NoopTextMapPropagator'), contains('MarkerPropagator')),
+      );
+    });
   });
 }


### PR DESCRIPTION
Fixes #42

Implements context/api-propagators.md, "Global Propagators":

- **"The OpenTelemetry API MUST provide a way to obtain a propagator for each supported Propagator type"** — `OTelAPI.textMapPropagator` get/set (`TextMapPropagator` is the single supported type today).
- **"The OpenTelemetry API MUST use no-op propagators unless explicitly configured otherwise"** — defaults to the new `const NoopTextMapPropagator` (`extract` returns the context unchanged; `inject` writes nothing).

**Design (revised per review):** the global lives on `OTelFactory` — like every other API object — so a replacement factory can substitute its own implementation; `OTelAPI.textMapPropagator` delegates through `_getAndCacheOtelFactory()` exactly like `context()`/`contextKey()`/the rest of the static surface. The factory's `reset()` clears it back to the lazy no-op default. A dedicated contract test proves the seam: a factory subclass overriding `textMapPropagator` supplies its own global.

Also per the same review pass over the pre-existing propagation files: `text_map_propagator.dart` and `context_propagator.dart` are pure contracts (nothing to route), but `CompositePropagator` was the one instantiable API object built by direct construction — it now has factory-routed creation too (`OTelAPI.compositePropagator` → `OTelFactory.compositePropagator`), with the public constructor doc-pointing at the factory path.

The surface is deliberately non-generic (`TextMapPropagator<dynamic, dynamic>`) so one global serves carriers of any type; propagator implementations stay generic and type-safe at their definition sites. Isolate-local, like the rest of the factory state.

**Tests:** builds on #43 — its pinned `fail()` is replaced by behavioral contracts (no-op default, extract/inject semantics, set/get round-trip, reset, debug logging, factory substitution, factory-routed composite creation); #43 can be closed as superseded when this merges. SDK follow-up (setting the global to the W3C composite in `initialize()`, honoring `OTEL_PROPAGATORS`) is out of scope for the API repo.

Verification: `dart analyze --fatal-infos` clean, 1,055 VM tests green, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)