### PR TITLE
docs: adopt the OpenTelemetry Generative AI policy; add AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+Instructions for AI agents (and their humans) working in
+`dartastic_opentelemetry_api`. Read [CONTRIBUTING.md](CONTRIBUTING.md)
+first — everything there applies, including the git hooks
+(`./tool/setup-hooks.sh`), the CHANGELOG conventions, and the
+OpenTelemetry
+[Generative AI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
+
+## Commit formatting
+
+We appreciate it if users disclose the use of AI tools when the significant part of a commit is
+taken from a tool without changes. When making a commit this should be disclosed through an
+Assisted-by: commit message trailer.
+
+Examples:
+
+Assisted-by: ChatGPT 5.2
+Assisted-by: Claude Opus 4.5
+
+## Architecture: one entrypoint, everything through factories
+
+This package is **not structured like most OpenTelemetry API packages**. In
+most language implementations you construct API objects directly. Here
+there is a single entrypoint — the `OTelAPI` class — backed by a factory
+layer, and all calls flow through them:
+
+- **`OTelAPI` is the front door.** Every object — tracer providers,
+  tracers, spans, attributes, baggage, context — is obtained from static
+  methods on `OTelAPI`, never by calling constructors. Most constructors
+  are private; creation code lives in `*_create.dart` part files next to
+  each class.
+- **A global factory does the construction.** `OTelFactory.otelFactory`
+  holds the installed factory. If API-only code runs first, a no-op
+  `OTelAPIFactory` is auto-installed, so the API alone is a spec-compliant
+  no-op. When an SDK (e.g.
+  [`dartastic_opentelemetry`](https://pub.dev/packages/dartastic_opentelemetry))
+  initializes, it replaces the factory with its own, upgrading every
+  subsequently created object to real telemetry — without user code
+  changing. This factory swap is also how platform (native vs web)
+  variants are selected.
+- **Consequence for changes:** adding a creatable type means threading it
+  through `OTelFactory`, not just adding a public constructor, so SDKs can
+  substitute their implementation. When tracing a call path, start at
+  `OTelAPI`, follow into the factory, then into the `*_create.dart` part
+  file — not at the class's constructor.
+
+The SDK mirrors this with `OTel` and `OTelSDKFactory`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+Read and follow [AGENTS.md](AGENTS.md) — the instructions there (commit
+formatting, architecture orientation, and contributor policies) apply to
+Claude sessions in this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,24 @@ Contributors should join the `#otel-dart` channel on the [CNCF Slack](https://sl
 
 This project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to the project maintainers.
 
+## Generative AI Policy
+
+This project follows the OpenTelemetry
+[Generative AI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md).
+In short: AI assistance is welcome for code, documentation, and tests, but
+**you remain in control and bear full responsibility** — review and validate
+everything before submitting, never post raw AI output as an issue, PR, or
+reply, and when AI generates the bulk of a commit, disclose it with an
+`Assisted-by:` commit trailer (e.g. `Assisted-by: Claude Opus 4.5`).
+Maintainers may close low-effort AI-generated contributions.
+
+**First-time contributors:** your first three contributions should be
+primarily human-written, and PR descriptions must be your own words — see
+the short guide at
+[Using AI](https://opentelemetry.io/docs/contributing/pull-requests/#using-ai).
+
+AI agents: see [AGENTS.md](AGENTS.md).
+
 ## Ways to Contribute
 
 There are many ways to contribute to this project:


### PR DESCRIPTION
Companion to MindfulSoftwareLLC/dartastic_opentelemetry#258.

- **CONTRIBUTING.md** gains a Generative AI Policy section summarizing and linking the [OTel GenAI policy](https://github.com/open-telemetry/community/blob/main/policies/genai.md), plus a shorter first-time-contributor note pointing at [Using AI](https://opentelemetry.io/docs/contributing/pull-requests/#using-ai).
- **AGENTS.md** carries the commit-formatting convention (`Assisted-by:` trailer with examples) and orients agents to the architecture: a single `OTelAPI` entrypoint and the `OTelFactory`/`OTelAPIFactory` layer — no-op until an SDK installs its factory, creation in `*_create.dart` part files, so call paths are traced from `OTelAPI` through the factory, not from constructors.
- **CLAUDE.md** points Claude at AGENTS.md.

Assisted-by: Claude Fable 5