### PR TITLE
fix(api): error-handling foundation + P0 propagation primitives (spec-compliance set 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-rc.2-wip]
 
 ### Added
+- **`OTelAPI.setErrorHandler` — a user-configurable global error handler**
+  (api#94). Internal misuse reports route through it instead of throwing;
+  the default handler logs via `OTelLog` and never throws. A user-installed
+  handler that throws propagates deliberately (strict mode), per
+  error-handling.md.
+
+### Fixed (spec compliance)
+- **`Span.end()` no longer promotes status from Unset to Ok** (api#60).
+  `Unset` stays `Unset`; analysis tools can no longer be misled by
+  fabricated Ok statuses. The deprecated `spanStatus` parameter still
+  flows through the `setStatus` rules when passed.
+- **`CompositePropagator.extract` walks propagators in the order they were
+  specified** (api#76), matching inject and every other OpenTelemetry SDK
+  (was reversed, so the last-registered propagator no longer wins extract).
+- **`Context.withSpanContext` returns a derived Context instead of throwing
+  `ArgumentError`** when the context already holds a span from a different
+  trace (api#77) — a routine situation during extraction.
+
+### Added
 - **Semantic conventions regenerated from registry v1.44.0** (previously
   v1.43.0-21-g436fa257). Additive only, per the VERSIONING.md policy: 47
   new identifiers, no renames and no removals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (api#94). Internal misuse reports route through it instead of throwing;
   the default handler logs via `OTelLog` and never throws. A user-installed
   handler that throws propagates deliberately (strict mode), per
-  error-handling.md. `Context.runIsolate` re-installs the parent's
-  handler inside the child isolate (handlers are copied; capture a
-  `SendPort` to aggregate reports across isolates — an unsendable
-  handler degrades to the child default and is reported).
+  error-handling.md. The handler is factory-held state: `OTelFactory`
+  carries the installed handler and an overridable `defaultErrorHandler`
+  for SDK factories, and a handler installed before any factory exists
+  is buffered and adopted at factory installation. `Context.runIsolate`
+  re-installs the parent's handler inside the child isolate (handlers
+  are copied; capture a `SendPort` to aggregate reports across isolates
+  — an unsendable handler degrades to the child default and is
+  reported).
 
 ### Fixed (spec compliance)
 - **`Span.end()` no longer promotes status from Unset to Ok** (api#60).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (api#94). Internal misuse reports route through it instead of throwing;
   the default handler logs via `OTelLog` and never throws. A user-installed
   handler that throws propagates deliberately (strict mode), per
-  error-handling.md.
+  error-handling.md. `Context.runIsolate` re-installs the parent's
+  handler inside the child isolate (handlers are copied; capture a
+  `SendPort` to aggregate reports across isolates — an unsendable
+  handler degrades to the child default and is reported).
 
 ### Fixed (spec compliance)
 - **`Span.end()` no longer promotes status from Unset to Ok** (api#60).

--- a/README.md
+++ b/README.md
@@ -258,6 +258,58 @@ void main() {
 }
 ```
 
+### Running traced work in another isolate
+
+Isolates share no mutable state, so context and configuration do not
+cross the boundary on their own. `Context.runIsolate` carries them for
+you — the OTel configuration, the active context (the propagated
+`SpanContext` arrives `isRemote: true`, like a context extracted from
+W3C headers), and your installed error handler:
+
+```dart
+final result = await Context.current.runIsolate(() async {
+  // OTel is configured, Context.current is this context, and the
+  // error handler behaves as in the parent.
+  return heavyComputation();
+});
+```
+
+Isolates spawned directly (`Isolate.spawn`, `compute`) start
+unconfigured. See [doc/isolates.md](doc/isolates.md) for the full
+story, including the SendPort pattern for aggregating error reports
+across isolates.
+
+### Error handling
+
+Per the OpenTelemetry [error-handling principles], the API never throws
+into application code when misused — invalid input degrades safely and
+is reported. Where those reports go is yours to configure:
+
+```dart
+// Default: reports are logged via OTelLog and never throw.
+// Route them to your own sink instead:
+OTelAPI.setErrorHandler((error, stackTrace) {
+  myTelemetryHealthMonitor.record(error, stackTrace);
+});
+
+// Strict mode for development — crash on any OTel misuse:
+OTelAPI.setErrorHandler((error, stackTrace) =>
+    Error.throwWithStackTrace(error, stackTrace ?? StackTrace.current));
+
+// Passing null restores the default logging handler.
+OTelAPI.setErrorHandler(null);
+```
+
+The handler receives the **library's** internal error reports (invalid
+attribute keys, malformed input, dropped data). Exceptions thrown by
+**your own code** inside `withSpan` blocks are never routed here — they
+always rethrow; how they are recorded on the span is controlled by the
+SDK's `SpanExceptionOptions`. The handler is a per-isolate global;
+`Context.runIsolate` re-installs it in child isolates
+([doc/isolates.md](doc/isolates.md)).
+
+[error-handling principles]: https://opentelemetry.io/docs/specs/otel/error-handling/
+
 ### Working with Attributes
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ OTelAPI.setErrorHandler((error, stackTrace) {
 OTelAPI.setErrorHandler((error, stackTrace) =>
     Error.throwWithStackTrace(error, stackTrace ?? StackTrace.current));
 
-// Passing null restores the default logging handler.
+// Passing null restores the default handler.
 OTelAPI.setErrorHandler(null);
 ```
 
@@ -304,8 +304,15 @@ The handler receives the **library's** internal error reports (invalid
 attribute keys, malformed input, dropped data). Exceptions thrown by
 **your own code** inside `withSpan` blocks are never routed here — they
 always rethrow; how they are recorded on the span is controlled by the
-SDK's `SpanExceptionOptions`. The handler is a per-isolate global;
-`Context.runIsolate` re-installs it in child isolates
+SDK's `SpanExceptionOptions`.
+
+Like every other OpenTelemetry global, the handler is held by the
+installed `OTelFactory`: `setErrorHandler` stores it on the factory —
+buffering it until one is installed, so the call is safe in any order
+relative to `initialize()` — and passing `null` returns to the
+factory's overridable `defaultErrorHandler` (logging via `OTelLog`,
+unless an SDK factory substitutes its own). Factories are per-isolate;
+`Context.runIsolate` re-installs your handler in child isolates
 ([doc/isolates.md](doc/isolates.md)).
 
 [error-handling principles]: https://opentelemetry.io/docs/specs/otel/error-handling/

--- a/doc/isolates.md
+++ b/doc/isolates.md
@@ -42,10 +42,15 @@ current context; everything behaves identically.
 
 ## The error handler crosses too — with copy semantics
 
-The global error handler installed with `OTelAPI.setErrorHandler` (or the
-SDK's `OTel.setErrorHandler`) is a per-isolate static. `runIsolate`
-re-installs the parent's handler inside the child so library error
-reports behave the same on both sides.
+The global error handler installed with `OTelAPI.setErrorHandler` (or
+the SDK's `OTel.setErrorHandler`) is held by the installed
+`OTelFactory`, which is per-isolate state. `runIsolate` delivers the
+parent's user-installed handler to the child over a port handshake
+before the child's factory exists; the child buffers it, and the
+factory installed by `OTelFactory.deserialize` adopts it — the same
+order-independent path as calling `setErrorHandler` before
+`initialize()`. Library error reports then behave the same on both
+sides.
 
 The handler is **copied**, not shared. A handler that logs, prints, or
 forwards to a crash reporter behaves identically in the child. A handler
@@ -71,6 +76,14 @@ closes over a `ReceivePort`, a stream controller, a socket, ...),
 logging handler and the parent's handler receives one report describing
 the degradation.
 
+Only **user-installed** handlers ride the handshake — factory defaults
+are never forwarded. With no user handler installed, the child resolves
+its own factory's `defaultErrorHandler` once `deserialize` has run. A
+custom factory that overrides `defaultErrorHandler`, or reconstructs a
+full handler natively in `deserialize()` / its `factoryFactory`,
+therefore needs no handshake at all: its error behavior travels with
+the factory itself.
+
 ## Isolates you spawn yourself
 
 `runIsolate` is the only isolate seam this library owns. If you use
@@ -92,9 +105,9 @@ the `withSpan` helpers make `Context.current` correct across `await`
 boundaries with no copying. Zones never cross isolates; `runIsolate` is
 the bridge for that.
 
-| Boundary                        | Mechanism                      | Context                   | Error handler                          |
-|---------------------------------|--------------------------------|---------------------------|----------------------------------------|
-| async/await (same isolate)      | zones (`context.run`)          | shared                    | shared (same static)                   |
-| `Context.runIsolate`            | serialize + re-establish       | copied, `isRemote: true`  | copied (SendPort pattern to aggregate) |
-| DIY `Isolate.spawn` / `compute` | none                           | empty                     | default                                |
-| processes                       | W3C propagators / env carriers | extracted, `isRemote: true` | not propagated                       |
+| Boundary                        | Mechanism                      | Context                     | Error handler                          |
+|---------------------------------|--------------------------------|-----------------------------|----------------------------------------|
+| async/await (same isolate)      | zones (`context.run`)          | shared                      | shared (same factory)                  |
+| `Context.runIsolate`            | serialize + re-establish       | copied, `isRemote: true`    | copied (SendPort pattern to aggregate) |
+| DIY `Isolate.spawn` / `compute` | none                           | empty                       | default                                |
+| processes                       | W3C propagators / env carriers | extracted, `isRemote: true` | not propagated                         |

--- a/doc/isolates.md
+++ b/doc/isolates.md
@@ -1,0 +1,100 @@
+# OpenTelemetry and Dart Isolates
+
+Dart isolates share no mutable state — every isolate has its own copy of
+globals, including OpenTelemetry's context, configuration, and error
+handler. This page explains what crosses an isolate boundary
+automatically, what doesn't, and the patterns to use.
+
+## The short version
+
+- Use **`Context.current.runIsolate(...)`** to run traced work in another
+  isolate. It carries your OTel configuration, the active context
+  (trace/span identity, baggage), **and your installed error handler**
+  into the child for you.
+- Isolates you spawn yourself (`Isolate.spawn`, `Isolate.run`, `compute`)
+  get **none** of that — each is a fresh, unconfigured OTel world until
+  you initialize it.
+
+## What `runIsolate` does
+
+```dart
+final result = await Context.current.runIsolate(() async {
+  // Runs in a new isolate with:
+  //  - the OTel factory configuration re-established,
+  //  - this context active (Context.current works),
+  //  - the parent's error handler installed (see below).
+  final span = tracer.startSpan('child-work');
+  // ...
+  span.end();
+  return computeSomething();
+});
+```
+
+Under the hood it serializes the factory configuration and the context,
+spawns the isolate, and re-establishes both before your computation runs.
+The propagated `SpanContext` arrives with `isRemote: true` — crossing an
+isolate boundary is treated like any other process boundary, exactly as
+if the context had arrived in W3C `traceparent` headers. Child spans
+therefore parent correctly onto the calling trace.
+
+On the web (no isolates), `runIsolate` runs the computation inline in the
+current context; everything behaves identically.
+
+## The error handler crosses too — with copy semantics
+
+The global error handler installed with `OTelAPI.setErrorHandler` (or the
+SDK's `OTel.setErrorHandler`) is a per-isolate static. `runIsolate`
+re-installs the parent's handler inside the child so library error
+reports behave the same on both sides.
+
+The handler is **copied**, not shared. A handler that logs, prints, or
+forwards to a crash reporter behaves identically in the child. A handler
+that collects into a local list collects into the **child's copy** — the
+parent never sees it. To aggregate reports in the parent, capture a
+`SendPort`:
+
+```dart
+final reports = ReceivePort();
+// Capture the SendPort itself. Capturing the ReceivePort — even
+// implicitly, by writing `reports.sendPort` inside the closure — makes
+// the handler unsendable.
+final sink = reports.sendPort;
+OTelAPI.setErrorHandler((error, stackTrace) {
+  sink.send(error.toString());
+});
+reports.listen((message) => log.warning('OTel error: $message'));
+```
+
+If a handler's captured state cannot be sent across the boundary (it
+closes over a `ReceivePort`, a stream controller, a socket, ...),
+`runIsolate` does **not** fail: the child falls back to the default
+logging handler and the parent's handler receives one report describing
+the degradation.
+
+## Isolates you spawn yourself
+
+`runIsolate` is the only isolate seam this library owns. If you use
+`Isolate.spawn` / `Isolate.run` / Flutter's `compute` directly, the new
+isolate starts with:
+
+- no OTel configuration (no-op behavior until initialized),
+- an empty `Context` (no active span, no baggage),
+- the **default** error handler.
+
+Either initialize OTel inside that isolate's entry point and re-install
+your handler there, or — usually simpler — route the work through
+`Context.current.runIsolate` instead.
+
+## Zones vs. isolates
+
+Within one isolate, context flows through zones: `context.run(...)` and
+the `withSpan` helpers make `Context.current` correct across `await`
+boundaries with no copying. Zones never cross isolates; `runIsolate` is
+the bridge for that.
+
+| Boundary | Mechanism | Context | Error handler |
+|---|---|---|---|
+| async/await (same isolate) | zones (`context.run`) | shared | shared (same static) |
+| `Context.runIsolate` | serialize + re-establish | copied, `isRemote: true` | copied (SendPort pattern to aggregate) |
+| DIY `Isolate.spawn` / `compute` | none | empty | default |
+| processes | W3C propagators / env carriers | extracted, `isRemote: true` | not propagated |

--- a/doc/isolates.md
+++ b/doc/isolates.md
@@ -92,9 +92,9 @@ the `withSpan` helpers make `Context.current` correct across `await`
 boundaries with no copying. Zones never cross isolates; `runIsolate` is
 the bridge for that.
 
-| Boundary | Mechanism | Context | Error handler |
-|---|---|---|---|
-| async/await (same isolate) | zones (`context.run`) | shared | shared (same static) |
-| `Context.runIsolate` | serialize + re-establish | copied, `isRemote: true` | copied (SendPort pattern to aggregate) |
-| DIY `Isolate.spawn` / `compute` | none | empty | default |
-| processes | W3C propagators / env carriers | extracted, `isRemote: true` | not propagated |
+| Boundary                        | Mechanism                      | Context                   | Error handler                          |
+|---------------------------------|--------------------------------|---------------------------|----------------------------------------|
+| async/await (same isolate)      | zones (`context.run`)          | shared                    | shared (same static)                   |
+| `Context.runIsolate`            | serialize + re-establish       | copied, `isRemote: true`  | copied (SendPort pattern to aggregate) |
+| DIY `Isolate.spawn` / `compute` | none                           | empty                     | default                                |
+| processes                       | W3C propagators / env carriers | extracted, `isRemote: true` | not propagated                       |

--- a/lib/dartastic_opentelemetry_api.dart
+++ b/lib/dartastic_opentelemetry_api.dart
@@ -72,6 +72,7 @@ export 'src/api/trace/tracer_provider.dart' hide TracerProviderCreate;
 export 'src/factory/otel_factory.dart';
 // Util
 export 'src/util/default_time_provider.dart';
+export 'src/util/otel_error_handler.dart';
 export 'src/util/otel_log.dart';
 export 'src/util/time_provider.dart';
 export 'src/util/web_time_provider.dart';

--- a/lib/src/api/baggage/baggage.dart
+++ b/lib/src/api/baggage/baggage.dart
@@ -3,7 +3,7 @@
 
 import 'package:meta/meta.dart';
 import '../../factory/otel_factory.dart';
-import '../../util/otel_log.dart';
+import '../../util/otel_error_handler.dart';
 import 'baggage_entry.dart';
 
 part 'baggage_create.dart';
@@ -25,7 +25,8 @@ class Baggage {
       : _entries = Map.unmodifiable(Map<String, BaggageEntry>.fromEntries(
             (entries ?? {}).entries.where((e) {
           if (e.key.isEmpty) {
-            OTelLog.warn('Baggage names must be non-empty; entry ignored.');
+            OTelErrorHandling.report(ArgumentError(
+                'Baggage names must be non-empty; entry ignored.'));
             return false;
           }
           return true;
@@ -58,7 +59,8 @@ class Baggage {
   /// Names must be non-empty per spec; an empty name is ignored and logged.
   Baggage copyWith(String key, String value, [String? metadata]) {
     if (key.isEmpty) {
-      OTelLog.warn('Baggage names must be non-empty; entry ignored.');
+      OTelErrorHandling.report(
+          ArgumentError('Baggage names must be non-empty; entry ignored.'));
       return this;
     }
     final factory = OTelFactory.getOrCreateDefault();

--- a/lib/src/api/common/attributes.dart
+++ b/lib/src/api/common/attributes.dart
@@ -8,7 +8,7 @@ import 'dart:convert';
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import '../../factory/otel_factory.dart';
-import '../../util/otel_log.dart';
+import '../../util/otel_error_handler.dart';
 import 'attribute.dart';
 
 part 'attributes_create.dart';
@@ -73,16 +73,16 @@ class Attributes {
                     .map((e) => e is int ? e.toDouble() : e as double)
                     .toList()));
           } else {
-            OTelLog.warn(
-                'Ignoring attribute $key because the list contains unsupported types. Only String, bool, int, double lists are allowed by the OTel specification.');
+            OTelErrorHandling.report(ArgumentError(
+                'Ignoring attribute $key because the list contains unsupported types. Only String, bool, int, double lists are allowed by the OTel specification.'));
           }
         } else {
-          OTelLog.warn(
-              'Ignoring attribute $key because empty lists are not allowed by the OTel specification.');
+          OTelErrorHandling.report(ArgumentError(
+              'Ignoring attribute $key because empty lists are not allowed by the OTel specification.'));
         }
       } else {
-        OTelLog.warn(
-            'Ignoring attribute $key because the value is not a valid attribute type. Only String, bool, int, double and Lists of those types are allowed by the OTel specification.');
+        OTelErrorHandling.report(ArgumentError(
+            'Ignoring attribute $key because the value is not a valid attribute type. Only String, bool, int, double and Lists of those types are allowed by the OTel specification.'));
       }
     }
 

--- a/lib/src/api/context/context.dart
+++ b/lib/src/api/context/context.dart
@@ -322,7 +322,7 @@ class Context {
     final serializedContext = serialize();
     final factoryFactory = oldFactory.factoryFactory;
 
-    return Isolate.run(() async {
+    Future<T> childMain() async {
       // Set up the factory in the new isolate.
       OTelFactory.otelFactory =
           OTelFactory.deserialize(serializedFactory, factoryFactory);
@@ -357,7 +357,11 @@ class Context {
         computation,
         zoneValues: {_zoneKey: isolateContext},
       );
-    });
+    }
+
+    // Spawn via the platform bridge, which re-installs the parent's
+    // error handler inside the child isolate first (api#94).
+    return runIsolateWithErrorHandlerBridge(childMain);
   }
 
   /// Serializes the context into a JSON-compatible map.

--- a/lib/src/api/context/context.dart
+++ b/lib/src/api/context/context.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import '../../factory/otel_factory.dart';
+import '../../util/otel_log.dart';
 import '../baggage/baggage.dart';
 import '../trace/span.dart';
 import '../trace/span_context.dart';
@@ -161,34 +162,28 @@ class Context {
     return copyWith(_baggageKey, baggage);
   }
 
-  /// Creates a new context with the given span context
+  /// Creates a new context with the given span context.
+  ///
+  /// Returns a new [Context] derived from this one with [spanContext] set,
+  /// replacing any existing span context — even one belonging to a
+  /// different trace. Per the OpenTelemetry Context specification a
+  /// set-value operation always returns a derived Context, and per the
+  /// Propagators API specification `extract` must never throw: receiving a
+  /// valid `traceparent` for another trace while a local span is active is
+  /// an ordinary situation, not an error. When the trace ID changes, a
+  /// debug log records the replacement. Use [withSpan] to make a span (and
+  /// its span context) current when creating child spans.
   Context withSpanContext(SpanContext spanContext) {
-    // First check the current span if any
-    final currentSpan = get<APISpan?>(_spanKey);
-    if (currentSpan != null &&
-        currentSpan.spanContext.isValid &&
-        spanContext.isValid &&
-        currentSpan.spanContext.traceId != spanContext.traceId) {
-      throw ArgumentError(
-          // ignore: prefer_adjacent_string_concatenation
-          'Cannot change trace ID when setting SpanContext. ' +
-              'Current trace ID: ${currentSpan.spanContext.traceId}, ' +
-              'New trace ID: ${spanContext.traceId}. ' +
-              'Use withSpan() for creating child spans.');
-    }
-
-    // Then check current span context
-    final currentSpanContext = get<SpanContext?>(_spanContextKey);
+    final currentSpanContext = get<APISpan?>(_spanKey)?.spanContext ??
+        get<SpanContext?>(_spanContextKey);
     if (currentSpanContext != null &&
         currentSpanContext.isValid &&
         spanContext.isValid &&
-        currentSpanContext.traceId != spanContext.traceId) {
-      throw ArgumentError(
-          // ignore: prefer_adjacent_string_concatenation
-          'Cannot change trace ID when setting SpanContext. ' +
-              'Current trace ID: ${currentSpanContext.traceId}, ' +
-              'New trace ID: ${spanContext.traceId}. ' +
-              'Use withSpan() for creating child spans.');
+        currentSpanContext.traceId != spanContext.traceId &&
+        OTelLog.isDebug()) {
+      OTelLog.debug('Context.withSpanContext: replacing span context of trace '
+          '${currentSpanContext.traceId} with span context of trace '
+          '${spanContext.traceId}.');
     }
 
     return copyWith(_spanContextKey, spanContext);

--- a/lib/src/api/context/isolate_support.dart
+++ b/lib/src/api/context/isolate_support.dart
@@ -23,22 +23,20 @@ Future<T> runIsolateComputation<T>(
 }
 
 /// Runs [childMain] in a new isolate, first delivering the parent's
-/// installed [OTelErrorHandling.handler] to the child over an explicit
-/// port handshake (api#94).
+/// user-installed error handler ([OTelErrorHandling.installedHandler],
+/// held by the parent's factory) to the child over an explicit port
+/// handshake (api#94).
 ///
-/// The default handler is never forwarded — the child's own default is
-/// identical. A handler whose captured state cannot cross the isolate
-/// boundary degrades to the child default (reported through the parent's
-/// handler) instead of failing the spawn. Handlers are copied, not
-/// shared: a handler that must aggregate in the parent should capture a
-/// [SendPort] and forward reports through it.
+/// Defaults are never forwarded: the child resolves its own factory's
+/// `defaultErrorHandler` once `OTelFactory.deserialize` has installed the
+/// child factory — a custom factory reconstructs its default natively. A
+/// handler whose captured state cannot cross the isolate boundary
+/// degrades to the child default (reported through the parent's handler)
+/// instead of failing the spawn. Handlers are copied, not shared: a
+/// handler that must aggregate in the parent should capture a [SendPort]
+/// and forward reports through it.
 Future<T> runIsolateWithErrorHandlerBridge<T>(Future<T> Function() childMain) {
-  final parentHandler = identical(
-    OTelErrorHandling.handler,
-    OTelErrorHandling.defaultErrorHandler,
-  )
-      ? null
-      : OTelErrorHandling.handler;
+  final parentHandler = OTelErrorHandling.installedHandler;
   if (parentHandler == null) {
     return Isolate.run(childMain);
   }
@@ -87,6 +85,10 @@ Future<T> _spawnWithHandlerHandshake<T>(
     final received = await handlerPort.first;
     handlerPort.close();
     if (received is OTelErrorHandler) {
+      // The child has no factory yet — childMain installs one via
+      // OTelFactory.deserialize. Installing here buffers the handler,
+      // and factory installation adopts it (the same pre-init path as
+      // OTelAPI.setErrorHandler before initialize()).
       OTelErrorHandling.handler = received;
     }
     return childMain();

--- a/lib/src/api/context/isolate_support.dart
+++ b/lib/src/api/context/isolate_support.dart
@@ -3,6 +3,8 @@
 
 import 'dart:isolate';
 
+import '../../util/otel_error_handler.dart';
+
 export 'dart:isolate';
 
 /// Runs a computation in a new isolate and returns the result.
@@ -17,5 +19,76 @@ Future<T> runIsolateComputation<T>(
     // This just re-exports dart:isolate for non-web platforms
     throw UnimplementedError(
         'runIsolateComputation should never be called directly');
+  });
+}
+
+/// Runs [childMain] in a new isolate, first delivering the parent's
+/// installed [OTelErrorHandling.handler] to the child over an explicit
+/// port handshake (api#94).
+///
+/// The default handler is never forwarded — the child's own default is
+/// identical. A handler whose captured state cannot cross the isolate
+/// boundary degrades to the child default (reported through the parent's
+/// handler) instead of failing the spawn. Handlers are copied, not
+/// shared: a handler that must aggregate in the parent should capture a
+/// [SendPort] and forward reports through it.
+Future<T> runIsolateWithErrorHandlerBridge<T>(Future<T> Function() childMain) {
+  final parentHandler = identical(
+    OTelErrorHandling.handler,
+    OTelErrorHandling.defaultErrorHandler,
+  )
+      ? null
+      : OTelErrorHandling.handler;
+  if (parentHandler == null) {
+    return Isolate.run(childMain);
+  }
+
+  final fromChild = ReceivePort();
+  final parentSend = fromChild.sendPort;
+  final sub = fromChild.listen((message) {
+    if (message is SendPort) {
+      try {
+        message.send(parentHandler);
+      } catch (_) {
+        // The handler's captured state is not sendable; the child keeps
+        // its default handler. Surface the degradation to the parent's
+        // handler so it is not silent.
+        message.send(null);
+        OTelErrorHandling.report(
+          StateError(
+            'OTel error handler could not be sent to a child isolate '
+            '(it captures non-sendable state); the child isolate ran '
+            'with the default handler. Capture a SendPort instead to '
+            'aggregate reports across isolates.',
+          ),
+        );
+      }
+    }
+  });
+
+  return _spawnWithHandlerHandshake(parentSend, childMain)
+      .whenComplete(() async {
+    await sub.cancel();
+    fromChild.close();
+  });
+}
+
+// A top-level function so the closure sent to the child isolate captures
+// only its (sendable) parameters. A local closure would share its context
+// object with sibling locals like the parent's ReceivePort, making the
+// whole message unsendable.
+Future<T> _spawnWithHandlerHandshake<T>(
+  SendPort parentSend,
+  Future<T> Function() childMain,
+) {
+  return Isolate.run(() async {
+    final handlerPort = ReceivePort();
+    parentSend.send(handlerPort.sendPort);
+    final received = await handlerPort.first;
+    handlerPort.close();
+    if (received is OTelErrorHandler) {
+      OTelErrorHandling.handler = received;
+    }
+    return childMain();
   });
 }

--- a/lib/src/api/context/isolate_support_web.dart
+++ b/lib/src/api/context/isolate_support_web.dart
@@ -27,3 +27,8 @@ Future<T> runIsolateComputation<T>(
   // On web, we just run the computation in the current context
   return await computation();
 }
+
+/// Web variant of the error-handler bridge: no isolate exists, so the
+/// installed handler is already ambient — just run the computation.
+Future<T> runIsolateWithErrorHandlerBridge<T>(Future<T> Function() childMain) =>
+    childMain();

--- a/lib/src/api/context/propagation/composite_propagator.dart
+++ b/lib/src/api/context/propagation/composite_propagator.dart
@@ -9,8 +9,10 @@ import 'text_map_propagator.dart';
 /// A propagator that combines multiple other propagators.
 ///
 /// Created via `OTelAPI.compositePropagator` (or an `OTelFactory`
-/// implementation), like every other API object. The propagators are
-/// applied in order for injection and in reverse order for extraction.
+/// implementation), like every other API object. Per the OpenTelemetry
+/// Propagators API specification, the propagators are invoked in the order
+/// they were specified, for both injection and extraction. When two
+/// propagators write the same Context slot, the last one specified wins.
 class CompositePropagator<C, V> implements TextMapPropagator<C, V> {
   final List<TextMapPropagator<C, V>> _propagators;
 
@@ -20,8 +22,7 @@ class CompositePropagator<C, V> implements TextMapPropagator<C, V> {
   @override
   Context extract(Context context, C carrier, TextMapGetter<V> getter) {
     var ctx = context;
-    // Apply propagators in reverse order
-    for (final propagator in _propagators.reversed) {
+    for (final propagator in _propagators) {
       ctx = propagator.extract(ctx, carrier, getter);
     }
     return ctx;

--- a/lib/src/api/factory/otel_api_factory.dart
+++ b/lib/src/api/factory/otel_api_factory.dart
@@ -4,7 +4,7 @@
 import 'dart:typed_data';
 
 import '../../factory/otel_factory.dart';
-import '../../util/otel_log.dart';
+import '../../util/otel_error_handler.dart';
 import '../baggage/baggage.dart';
 import '../baggage/baggage_entry.dart';
 import '../common/attribute.dart';
@@ -207,8 +207,8 @@ class OTelAPIFactory extends OTelFactory {
                     .map((e) => e is int ? e.toDouble() : e as double)
                     .toList()));
           } else {
-            OTelLog.warn(
-                'Ignoring attribute $key because the list contains unsupported types. Only String, bool, int, double lists are allowed by the OTel specification.');
+            OTelErrorHandling.report(ArgumentError(
+                'Ignoring attribute $key because the list contains unsupported types. Only String, bool, int, double lists are allowed by the OTel specification.'));
           }
         }
       } else {

--- a/lib/src/api/logs/logger_provider.dart
+++ b/lib/src/api/logs/logger_provider.dart
@@ -4,7 +4,7 @@
 // ignore_for_file: unnecessary_getters_setters
 
 import 'package:meta/meta.dart';
-import '../../util/otel_log.dart';
+import '../../util/otel_error_handler.dart';
 import '../common/attributes.dart';
 import '../common/signal_instance_key.dart';
 import '../otel_api.dart';
@@ -74,15 +74,15 @@ class APILoggerProvider {
     Attributes? attributes,
   }) {
     if (_isShutdown) {
-      OTelLog.warn(
-          'getLogger called after shutdown; returning a no-op logger.');
+      OTelErrorHandling.report(StateError(
+          'getLogger called after shutdown; returning a no-op logger.'));
     }
 
-    // Validate the logger name; if invalid (empty), log a warning and use empty string.
+    // Validate the logger name; if invalid (empty), report and use empty string.
     final validatedName = name.isEmpty ? '' : name;
     if (validatedName.isEmpty) {
-      OTelLog.warn(
-          'Invalid log name provided; using empty string as fallback.');
+      OTelErrorHandling.report(ArgumentError(
+          'Invalid log name provided; using empty string as fallback.'));
     }
 
     // Apply default values if none are provided

--- a/lib/src/api/metrics/meter_provider.dart
+++ b/lib/src/api/metrics/meter_provider.dart
@@ -4,7 +4,7 @@
 // ignore_for_file: unnecessary_getters_setters
 
 import 'package:meta/meta.dart';
-import '../../util/otel_log.dart';
+import '../../util/otel_error_handler.dart';
 import '../common/attributes.dart';
 import '../common/signal_instance_key.dart';
 import '../otel_api.dart';
@@ -79,14 +79,15 @@ class APIMeterProvider {
       String? schemaUrl,
       Attributes? attributes}) {
     if (_isShutdown) {
-      OTelLog.warn('getMeter called after shutdown; returning a no-op meter.');
+      OTelErrorHandling.report(StateError(
+          'getMeter called after shutdown; returning a no-op meter.'));
     }
 
-    // Validate the meter name; if invalid (empty), log a warning and use empty string.
+    // Validate the meter name; if invalid (empty), report and use empty string.
     final validatedName = name.isEmpty ? '' : name;
     if (validatedName.isEmpty) {
-      OTelLog.warn(
-          'Invalid meter name provided; using empty string as fallback.');
+      OTelErrorHandling.report(ArgumentError(
+          'Invalid meter name provided; using empty string as fallback.'));
     }
 
     // Create a cache key based on the provided parameters.

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -779,7 +779,14 @@ class OTelAPI {
   /// Per the OpenTelemetry specification (error-handling.md), the library
   /// never throws for invalid API usage at runtime; suppressed errors are
   /// reported to this handler instead. Pass `null` to restore the default
-  /// logging handler. Equivalent to setting [OTelErrorHandling.handler].
+  /// behavior — the installed factory's [OTelFactory.defaultErrorHandler],
+  /// which logs through [OTelLog] unless an SDK factory overrides it.
+  ///
+  /// Like every other global, the handler is held by the installed
+  /// [OTelFactory] ([OTelFactory.errorHandler]). Calling this before any
+  /// factory is installed is safe: the handler is buffered and adopted
+  /// when a factory is installed, so it works in any order relative to
+  /// `initialize()`.
   ///
   /// ```dart
   /// // Fail fast on invalid API usage, e.g. in a staging environment:
@@ -806,6 +813,9 @@ class OTelAPI {
   @visibleForTesting
   static void reset() {
     _otelFactory = null;
+    // Restore default error handling: clears the factory-held user
+    // handler and any handler buffered before a factory was installed.
+    OTelErrorHandling.resetToDefault();
     OTelFactory.otelFactory?.reset();
     // ignore: invalid_use_of_visible_for_testing_member
     Context.resetRoot();

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import '../factory/otel_factory.dart';
+import '../util/otel_error_handler.dart';
 import '../util/otel_log.dart';
 import 'baggage/baggage.dart';
 import 'baggage/baggage_entry.dart';
@@ -770,6 +771,27 @@ class OTelAPI {
       [Attributes? attributes]) {
     _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.createMeasurement(value, attributes);
+  }
+
+  /// Installs a global error handler, replacing the default behavior of
+  /// logging suppressed errors through [OTelLog].
+  ///
+  /// Per the OpenTelemetry specification (error-handling.md), the library
+  /// never throws for invalid API usage at runtime; suppressed errors are
+  /// reported to this handler instead. Pass `null` to restore the default
+  /// logging handler. Equivalent to setting [OTelErrorHandling.handler].
+  ///
+  /// ```dart
+  /// // Fail fast on invalid API usage, e.g. in a staging environment:
+  /// OTelAPI.setErrorHandler((error, stackTrace) =>
+  ///     Error.throwWithStackTrace(error, stackTrace ?? StackTrace.current));
+  /// ```
+  static void setErrorHandler(OTelErrorHandler? handler) {
+    if (handler == null) {
+      OTelErrorHandling.resetToDefault();
+    } else {
+      OTelErrorHandling.handler = handler;
+    }
   }
 
   static OTelFactory _getAndCacheOtelFactory() {

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -420,17 +420,28 @@ class APISpan {
   }
 
   /// Marks the end of the Span execution.
-  /// By default the end time is set to the calling time and
-  /// the span status is [SpanStatusCode.Ok]
+  ///
+  /// [endTime] optionally sets an explicit end timestamp; when omitted it
+  /// is set to the current time, per trace/api.md (End).
+  ///
+  /// End never changes the span status: a span whose status was never set
+  /// remains [SpanStatusCode.Unset]. Per trace/api.md (Set Status),
+  /// instrumentation SHOULD leave the status as Unset unless there is an
+  /// error, and SHOULD NOT set Ok unless explicitly configured to do so.
   ///
   /// Only the first call to end modifies the Span.
-  void end({DateTime? endTime, SpanStatusCode? spanStatus}) {
+  void end({
+    DateTime? endTime,
+    @Deprecated('The spec End operation takes only an optional timestamp. '
+        'Call setStatus() before end() instead. When given, this is applied '
+        'through the setStatus rules and no longer defaults to Ok.')
+    SpanStatusCode? spanStatus,
+  }) {
     if (_modifiable) {
-      _endTime = endTime ?? _timeProvider.nowDateTime();
-      // Only set status if no status has been set
-      if (_spanStatusCode == null || _spanStatusCode == SpanStatusCode.Unset) {
-        _spanStatusCode = spanStatus ?? SpanStatusCode.Ok;
+      if (spanStatus != null) {
+        setStatus(spanStatus);
       }
+      _endTime = endTime ?? _timeProvider.nowDateTime();
     }
   }
 

--- a/lib/src/api/trace/trace_state.dart
+++ b/lib/src/api/trace/trace_state.dart
@@ -3,7 +3,7 @@
 
 import 'package:meta/meta.dart';
 import '../../factory/otel_factory.dart';
-import '../../util/otel_log.dart';
+import '../../util/otel_error_handler.dart';
 
 part 'trace_state_create.dart';
 
@@ -77,7 +77,8 @@ class TraceState {
   ///  the oldest entries are removed to make room.
   TraceState put(String key, String value) {
     if (!_isValidKey(key) || !_isValidValue(value)) {
-      OTelLog.warn('Invalid TraceState key or value; entry ignored.');
+      OTelErrorHandling.report(
+          ArgumentError('Invalid TraceState key or value; entry ignored.'));
       return this;
     }
     final factory = OTelFactory.getOrCreateDefault();

--- a/lib/src/api/trace/tracer_provider.dart
+++ b/lib/src/api/trace/tracer_provider.dart
@@ -5,7 +5,7 @@
 
 import 'package:meta/meta.dart';
 import '../../util/default_time_provider.dart';
-import '../../util/otel_log.dart';
+import '../../util/otel_error_handler.dart';
 import '../../util/time_provider.dart';
 import '../common/attributes.dart';
 import '../common/signal_instance_key.dart';
@@ -84,15 +84,15 @@ class APITracerProvider {
   APITracer getTracer(String name,
       {String? version, String? schemaUrl, Attributes? attributes}) {
     if (_isShutdown) {
-      OTelLog.warn(
-          'getTracer called after shutdown; returning a no-op tracer.');
+      OTelErrorHandling.report(StateError(
+          'getTracer called after shutdown; returning a no-op tracer.'));
     }
 
-    // Validate the tracer name; if invalid (empty), log a warning and use empty string.
+    // Validate the tracer name; if invalid (empty), report and use empty string.
     final validatedName = name.isEmpty ? '' : name;
     if (validatedName.isEmpty) {
-      OTelLog.warn(
-          'Invalid tracer name provided; using empty string as fallback.');
+      OTelErrorHandling.report(ArgumentError(
+          'Invalid tracer name provided; using empty string as fallback.'));
     }
 
     // Apply default values if none are provided

--- a/lib/src/factory/otel_factory.dart
+++ b/lib/src/factory/otel_factory.dart
@@ -34,6 +34,7 @@ import '../api/trace/trace_flags.dart';
 import '../api/trace/trace_id.dart';
 import '../api/trace/trace_state.dart';
 import '../api/trace/tracer_provider.dart';
+import '../util/otel_error_handler.dart';
 import '../util/otel_log.dart';
 
 /// A function that creates the OTel Factory, used bu initialize methods
@@ -52,9 +53,31 @@ abstract class OTelFactory {
   /// For gRPC, callers must pass `http://localhost:4317` explicitly.
   static const defaultEndpoint = 'http://localhost:4318';
 
+  static OTelFactory? _installedFactory;
+
   /// SDKs must replace this otelFactory with their own to get the SDK
   /// object created instead of the API default implementation
-  static OTelFactory? otelFactory;
+  static OTelFactory? get otelFactory => _installedFactory;
+
+  /// Installs [factory] as the global factory.
+  ///
+  /// Installation adopts error-handler state so a user handler is never
+  /// lost: a handler buffered by [OTelAPI.setErrorHandler] before any
+  /// factory existed moves onto [factory], and a handler held by a
+  /// factory being replaced (e.g. the auto-installed no-op API factory
+  /// upgraded by an SDK) carries over unless [factory] already holds its
+  /// own.
+  static set otelFactory(OTelFactory? factory) {
+    final previous = _installedFactory;
+    _installedFactory = factory;
+    if (factory != null && !identical(factory, previous)) {
+      final previousHandler = previous?.errorHandler;
+      if (previousHandler != null) {
+        factory.errorHandler ??= previousHandler;
+      }
+      OTelErrorHandling.adoptPendingHandler(factory);
+    }
+  }
 
   String _apiEndpoint;
   String _apiServiceName;
@@ -493,6 +516,32 @@ abstract class OTelFactory {
     _textMapPropagator = propagator;
   }
 
+  /// The user-installed global error handler, or `null` when none is
+  /// installed.
+  ///
+  /// Like every other OpenTelemetry global, the handler lives on the
+  /// factory so that a replacement factory can substitute its own
+  /// behavior. [OTelAPI.setErrorHandler] is the user-facing surface;
+  /// [OTelErrorHandling.report] resolves to this handler, falling back to
+  /// [defaultErrorHandler] when it is `null`. Setting it to `null`
+  /// restores [defaultErrorHandler] behavior.
+  OTelErrorHandler? errorHandler;
+
+  /// The default error handler used whenever no user [errorHandler] is
+  /// installed: [OTelErrorHandling.defaultErrorHandler], which logs
+  /// through [OTelLog] and never throws.
+  ///
+  /// Factory subclasses (SDK factories) may override this getter to
+  /// supply their own default reporting behavior — for example, routing
+  /// suppressed errors to the SDK's self-diagnostics. A user handler
+  /// installed with [OTelAPI.setErrorHandler] always wins over this
+  /// default; `OTelAPI.setErrorHandler(null)` returns to it. A factory
+  /// that overrides this getter reconstructs its default natively in
+  /// `deserialize()`/[factoryFactory] on the far side of an isolate
+  /// boundary — defaults are never forwarded between isolates.
+  OTelErrorHandler get defaultErrorHandler =>
+      OTelErrorHandling.defaultErrorHandler;
+
   void reset() {
     _apiEndpoint = defaultEndpoint;
     _apiServiceName = OTelAPI.defaultServiceName;
@@ -504,6 +553,7 @@ abstract class OTelFactory {
     _meterProviders?.clear();
     _meterProviders = null;
     _textMapPropagator = null;
+    errorHandler = null;
     otelFactory = null;
   }
 

--- a/lib/src/util/otel_error_handler.dart
+++ b/lib/src/util/otel_error_handler.dart
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'otel_log.dart';
+
+/// Signature of a global OpenTelemetry error handler.
+///
+/// Invoked whenever the library suppresses an error that would otherwise
+/// have surfaced to the user, per the OpenTelemetry specification
+/// (error-handling.md):
+///
+/// > OpenTelemetry implementations MUST NOT throw unhandled exceptions
+/// > at runtime.
+///
+/// > SDK implementations MUST allow end users to change the library's
+/// > default error handling behavior for relevant errors.
+///
+/// [error] is the suppressed error, typically an [ArgumentError] or
+/// [StateError] describing the invalid API use. [stackTrace] is the stack
+/// at the point the error was reported, when one is available.
+typedef OTelErrorHandler = void Function(Object error, StackTrace? stackTrace);
+
+/// The global error-handling policy hook for OpenTelemetry.
+///
+/// Per error-handling.md, "Configuring Error Handlers", replacing
+/// [handler] is the supported way for end users to change the library's
+/// default error handling behavior — for example, to fail fast on invalid
+/// API usage in a staging environment:
+///
+/// ```dart
+/// OTelErrorHandling.handler = (error, stackTrace) =>
+///     Error.throwWithStackTrace(error, stackTrace ?? StackTrace.current);
+/// ```
+///
+/// The default handler logs through [OTelLog.error], following the
+/// self-diagnostics guidance ("the library SHOULD log the error using
+/// language-specific conventions"), and never throws itself.
+///
+/// Library code reports suppressed errors through [report]. An exception
+/// deliberately thrown by a user-installed handler propagates to the
+/// caller: per the spec, "configuring a custom error handler in this way
+/// is the only exception to the basic error handling principles".
+class OTelErrorHandling {
+  OTelErrorHandling._();
+
+  /// The currently installed error handler.
+  ///
+  /// Assign a new [OTelErrorHandler] to replace the default logging
+  /// behavior. Use [resetToDefault] to restore [defaultErrorHandler].
+  static OTelErrorHandler handler = defaultErrorHandler;
+
+  /// Restores the [defaultErrorHandler].
+  static void resetToDefault() => handler = defaultErrorHandler;
+
+  /// Reports a suppressed [error] to the installed [handler].
+  ///
+  /// Used by the library wherever the specification forbids throwing and
+  /// an invalid input or internal failure is swallowed instead. With the
+  /// default handler this never throws; a user-installed handler that
+  /// throws (e.g. strict mode in staging) propagates by design.
+  static void report(Object error, [StackTrace? stackTrace]) {
+    handler(error, stackTrace);
+  }
+
+  /// The default error handler: logs the error (and stack trace, when
+  /// present) through [OTelLog.error].
+  static void defaultErrorHandler(Object error, StackTrace? stackTrace) {
+    if (OTelLog.isError()) {
+      OTelLog.error('$error');
+      if (stackTrace != null) {
+        OTelLog.error('Stack trace: $stackTrace');
+      }
+    }
+  }
+}

--- a/lib/src/util/otel_error_handler.dart
+++ b/lib/src/util/otel_error_handler.dart
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:meta/meta.dart';
+
+import '../factory/otel_factory.dart';
 import 'otel_log.dart';
 
 /// Signature of a global OpenTelemetry error handler.
@@ -20,17 +23,32 @@ import 'otel_log.dart';
 /// at the point the error was reported, when one is available.
 typedef OTelErrorHandler = void Function(Object error, StackTrace? stackTrace);
 
+/// Buffers a handler installed before any [OTelFactory] exists. Factory
+/// installation adopts it (see the [OTelFactory.otelFactory] setter), so
+/// installing a handler before `initialize()` never throws and is never
+/// lost.
+OTelErrorHandler? _pendingHandler;
+
 /// The global error-handling policy hook for OpenTelemetry.
 ///
-/// Per error-handling.md, "Configuring Error Handlers", replacing
-/// [handler] is the supported way for end users to change the library's
-/// default error handling behavior — for example, to fail fast on invalid
-/// API usage in a staging environment:
+/// Per error-handling.md, "Configuring Error Handlers", installing a
+/// handler (via [OTelAPI.setErrorHandler], or [handler] directly) is the
+/// supported way for end users to change the library's default error
+/// handling behavior — for example, to fail fast on invalid API usage in
+/// a staging environment:
 ///
 /// ```dart
-/// OTelErrorHandling.handler = (error, stackTrace) =>
-///     Error.throwWithStackTrace(error, stackTrace ?? StackTrace.current);
+/// OTelAPI.setErrorHandler((error, stackTrace) =>
+///     Error.throwWithStackTrace(error, stackTrace ?? StackTrace.current));
 /// ```
+///
+/// Like every other OpenTelemetry global in this library, the handler is
+/// held by the installed [OTelFactory]: the user-installed handler lives
+/// in [OTelFactory.errorHandler], and when none is installed reports fall
+/// back to [OTelFactory.defaultErrorHandler] — which SDK factories may
+/// override. Before any factory exists, an installed handler is buffered
+/// and adopted by the first factory installation, so configuration order
+/// never matters.
 ///
 /// The default handler logs through [OTelLog.error], following the
 /// self-diagnostics guidance ("the library SHOULD log the error using
@@ -43,16 +61,61 @@ typedef OTelErrorHandler = void Function(Object error, StackTrace? stackTrace);
 class OTelErrorHandling {
   OTelErrorHandling._();
 
-  /// The currently installed error handler.
+  /// The handler [report] currently resolves to.
   ///
-  /// Assign a new [OTelErrorHandler] to replace the default logging
-  /// behavior. Use [resetToDefault] to restore [defaultErrorHandler].
-  static OTelErrorHandler handler = defaultErrorHandler;
+  /// Resolution order: the user-installed handler (factory-held, or
+  /// buffered when no factory exists yet), then the installed factory's
+  /// [OTelFactory.defaultErrorHandler], then [defaultErrorHandler].
+  /// Reading this never installs a factory as a side effect.
+  static OTelErrorHandler get handler {
+    final factory = OTelFactory.otelFactory;
+    if (factory != null) {
+      return factory.errorHandler ?? factory.defaultErrorHandler;
+    }
+    return _pendingHandler ?? defaultErrorHandler;
+  }
 
-  /// Restores the [defaultErrorHandler].
-  static void resetToDefault() => handler = defaultErrorHandler;
+  /// Installs [value] as the user handler, replacing the default
+  /// behavior. Stored on the installed [OTelFactory]; buffered until one
+  /// exists. Use [resetToDefault] to restore the default behavior.
+  static set handler(OTelErrorHandler value) {
+    final factory = OTelFactory.otelFactory;
+    if (factory != null) {
+      factory.errorHandler = value;
+    } else {
+      _pendingHandler = value;
+    }
+  }
 
-  /// Reports a suppressed [error] to the installed [handler].
+  /// The user-installed handler, or `null` when only defaults (the
+  /// logging default, or a factory subclass's default) are in effect.
+  static OTelErrorHandler? get installedHandler {
+    final factory = OTelFactory.otelFactory;
+    return factory != null ? factory.errorHandler : _pendingHandler;
+  }
+
+  /// Restores the default behavior: clears the user-installed handler
+  /// (factory-held and buffered alike), so [report] falls back to the
+  /// installed factory's [OTelFactory.defaultErrorHandler] — the logging
+  /// [defaultErrorHandler] unless a factory subclass overrides it.
+  static void resetToDefault() {
+    _pendingHandler = null;
+    OTelFactory.otelFactory?.errorHandler = null;
+  }
+
+  /// Moves a handler buffered before [factory] existed into the factory's
+  /// [OTelFactory.errorHandler] slot. Called by the [OTelFactory.otelFactory]
+  /// setter on every factory installation; not part of the public API.
+  @internal
+  static void adoptPendingHandler(OTelFactory factory) {
+    final pending = _pendingHandler;
+    if (pending != null) {
+      _pendingHandler = null;
+      factory.errorHandler = pending;
+    }
+  }
+
+  /// Reports a suppressed [error] to the resolved [handler].
   ///
   /// Used by the library wherever the specification forbids throwing and
   /// an invalid input or internal failure is swallowed instead. With the

--- a/test/unit/api/context/context_api_coverage_test.dart
+++ b/test/unit/api/context/context_api_coverage_test.dart
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Coverage for Context.withSpanContext trace-change rejection and the
+// Coverage for Context.withSpanContext trace replacement and the
 // ContextKey uniqueId/toString surface.
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
@@ -18,7 +18,13 @@ void main() {
       );
     });
 
-    test('withSpanContext rejects changing the trace ID', () {
+    test(
+        'withSpanContext returns a derived context when the Context holds '
+        'a span of another trace', () {
+      // Per the Propagators API spec, extract "MUST NOT throw": a service
+      // with an active local span in trace A that receives a valid
+      // traceparent for trace B is an ordinary situation. withSpanContext
+      // sits on that extraction path, so it must derive, never throw.
       final sc1 = OTelAPI.spanContext(
         traceId: OTelAPI.traceId(),
         spanId: OTelAPI.spanId(),
@@ -30,14 +36,11 @@ void main() {
       final span = OTelAPI.nonRecordingSpan(sc1);
       final context = Context.root.withSpan(span);
 
-      expect(
-        () => context.withSpanContext(sc2),
-        throwsA(isA<ArgumentError>().having(
-          (e) => e.message,
-          'message',
-          contains('Cannot change trace ID'),
-        )),
-      );
+      final derived = context.withSpanContext(sc2);
+      expect(derived.spanContext, equals(sc2));
+
+      // The original context is unchanged.
+      expect(context.spanContext, equals(sc1));
     });
 
     test('ContextKey exposes uniqueId and a descriptive toString', () {

--- a/test/unit/api/context/context_coverage_test.dart
+++ b/test/unit/api/context/context_coverage_test.dart
@@ -143,7 +143,8 @@ void main() {
       });
     });
 
-    test('Context throws when withSpanContext changes trace ID', () {
+    test('Context.withSpanContext replaces a span context of another trace',
+        () {
       // Create two span contexts with different trace IDs
       final spanContext1 = OTelAPI.spanContext(
         traceId: OTelAPI.traceId(),
@@ -158,10 +159,11 @@ void main() {
       // First set spanContext1
       final context1 = Context.root.withSpanContext(spanContext1);
 
-      // Then try to set spanContext2 with a different trace ID
-      expect(() {
-        context1.withSpanContext(spanContext2);
-      }, throwsArgumentError);
+      // Setting spanContext2 with a different trace ID must not throw:
+      // a Context set-value operation returns a derived Context.
+      final context2 = context1.withSpanContext(spanContext2);
+      expect(context2.spanContext, equals(spanContext2));
+      expect(context1.spanContext, equals(spanContext1));
     });
 
     test('Context.get returns null when value type does not match', () {

--- a/test/unit/api/context/propagation/composite_propagator_test.dart
+++ b/test/unit/api/context/propagation/composite_propagator_test.dart
@@ -101,7 +101,7 @@ void main() {
       expect(fields.length, equals(4)); // No duplicates
     });
 
-    test('extract() applies propagators in reverse order', () {
+    test('extract() applies propagators in the order they were specified', () {
       final propagator1 = MockPropagator('p1', ['field1']);
       final propagator2 = MockPropagator('p2', ['field2']);
       final propagator3 = MockPropagator('p3', ['field3']);
@@ -120,10 +120,41 @@ void main() {
 
       final extractedContext = composite.extract(context, carrier, getter);
 
-      // Propagators should be applied in reverse order (p3, p2, p1)
+      // Each propagator extracts its own field
       expect(extractedContext.baggage?.getValue('field1'), equals('p1:value1'));
       expect(extractedContext.baggage?.getValue('field2'), equals('p2:value2'));
       expect(extractedContext.baggage?.getValue('field3'), equals('p3:value3'));
+    });
+
+    test(
+        'extract() lets the last propagator win when two propagators '
+        'write the same Context slot', () {
+      // Per the Propagators API spec, the composite invokes propagators
+      // "in the order they were specified". When two propagators extract
+      // into the same slot, the last one specified must win.
+      final propagator1 = MockPropagator('p1', ['shared']);
+      final propagator2 = MockPropagator('p2', ['shared']);
+
+      final composite =
+          OTelAPI.compositePropagator<Map<String, String>, String>(
+              [propagator1, propagator2]);
+
+      final carrier = {'shared': 'value'};
+      final getter = MockTextMapGetter(carrier);
+
+      final extractedContext =
+          composite.extract(OTelAPI.context(), carrier, getter);
+
+      expect(extractedContext.baggage?.getValue('shared'), equals('p2:value'));
+
+      // Reversing the registration order reverses the winner.
+      final reversedComposite =
+          OTelAPI.compositePropagator<Map<String, String>, String>(
+              [propagator2, propagator1]);
+      final reversedContext =
+          reversedComposite.extract(OTelAPI.context(), carrier, getter);
+
+      expect(reversedContext.baggage?.getValue('shared'), equals('p1:value'));
     });
 
     test('extract() preserves original context for fields not in carrier', () {

--- a/test/unit/api/context/run_isolate_error_handler_test.dart
+++ b/test/unit/api/context/run_isolate_error_handler_test.dart
@@ -1,0 +1,83 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+@TestOn('vm')
+library;
+
+import 'dart:isolate';
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Context.runIsolate error handler propagation (api#94)', () {
+    setUp(() {
+      OTelAPI.reset();
+      OTelAPI.initialize(
+        endpoint: 'http://localhost:4317',
+        serviceName: 'test-service',
+        serviceVersion: '1.0.0',
+      );
+    });
+
+    tearDown(OTelErrorHandling.resetToDefault);
+
+    test('the installed handler crosses into the child isolate', () async {
+      // A handler that captures only a SendPort is sendable, so its copy in
+      // the child forwards reports back to the parent — the documented
+      // pattern for aggregating reports across isolates.
+      final received = ReceivePort();
+      // Capture the SendPort itself — capturing the ReceivePort (even via
+      // `received.sendPort` inside the closure) makes the handler
+      // unsendable and triggers the degradation path instead.
+      final reportSink = received.sendPort;
+      OTelAPI.setErrorHandler((error, stackTrace) {
+        reportSink.send(error.toString());
+      });
+
+      await Context.current.runIsolate(() async {
+        OTelErrorHandling.report(StateError('report-from-child'));
+      });
+
+      final first = await received.first.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => fail(
+          'The child isolate ran with the default handler; the '
+          'parent-installed handler was not re-installed by runIsolate.',
+        ),
+      );
+      expect(first, contains('report-from-child'));
+      received.close();
+    });
+
+    test('the default handler is not needlessly forwarded', () async {
+      // With no user handler installed, the child must simply keep its own
+      // default (logging) handler; runIsolate must not fail attempting to
+      // send the default.
+      final result = await Context.current.runIsolate(() async {
+        OTelErrorHandling.report(StateError('default-ok'));
+        return identical(
+          OTelErrorHandling.handler,
+          OTelErrorHandling.defaultErrorHandler,
+        );
+      });
+      expect(result, isTrue,
+          reason: 'child should run the default handler when the parent '
+              'has none installed');
+    });
+
+    test('an unsendable handler degrades gracefully', () async {
+      // A handler closing over a ReceivePort cannot be sent to the child.
+      // runIsolate must still run the computation (with the child default
+      // handler) rather than throwing at spawn.
+      final unsendable = ReceivePort();
+      OTelAPI.setErrorHandler((error, stackTrace) {
+        unsendable.hashCode; // captures the ReceivePort
+      });
+
+      final value = await Context.current.runIsolate(() async => 42);
+      expect(value, equals(42));
+      unsendable.close();
+    });
+  });
+}

--- a/test/unit/api/context/run_isolate_factory_adoption_test.dart
+++ b/test/unit/api/context/run_isolate_factory_adoption_test.dart
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// api#94 — the isolate bridge goes through the factory-held error handler.
+//
+// Ordering subtlety pinned here: in the child isolate the bridged handler
+// arrives over the port handshake BEFORE `OTelFactory.deserialize` installs
+// the child's factory. The pre-init buffer semantics must carry the
+// handler onto the factory once it is installed — the child-side install
+// is the same "setErrorHandler before initialize" path a user takes.
+
+@TestOn('vm')
+library;
+
+import 'dart:isolate';
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(
+      'runIsolate installs the bridged handler onto the child factory '
+      '(api#94)', () {
+    setUp(() {
+      OTelAPI.reset();
+      OTelAPI.initialize(
+        endpoint: 'http://localhost:4317',
+        serviceName: 'test-service',
+        serviceVersion: '1.0.0',
+      );
+    });
+
+    tearDown(OTelAPI.reset);
+
+    test('the handshake handler is adopted by the child factory', () async {
+      final received = ReceivePort();
+      final reportSink = received.sendPort;
+      OTelAPI.setErrorHandler((error, stackTrace) {
+        reportSink.send(error.toString());
+      });
+
+      final childSaw = await Context.current.runIsolate(() async {
+        // The handler arrived before the child factory existed; adoption
+        // must have moved it onto the factory installed by deserialize.
+        final onFactory = OTelFactory.otelFactory!.errorHandler != null;
+        final installed = OTelErrorHandling.installedHandler != null;
+        OTelErrorHandling.report(StateError('adopted-report'));
+        return [onFactory, installed];
+      });
+
+      expect(childSaw, equals([true, true]),
+          reason: 'the bridged handler must be held by the child factory '
+              'and visible as the installed handler');
+
+      final first = await received.first.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => fail(
+          'The child-side report did not route through the bridged handler.',
+        ),
+      );
+      expect(first, contains('adopted-report'));
+      received.close();
+    });
+
+    test('with no user handler the child factory slot stays empty', () async {
+      final childSaw = await Context.current.runIsolate(() async {
+        return [
+          OTelFactory.otelFactory!.errorHandler == null,
+          OTelErrorHandling.installedHandler == null,
+        ];
+      });
+      expect(childSaw, equals([true, true]),
+          reason: 'defaults are never forwarded; the child resolves its '
+              'own factory default');
+    });
+  });
+}

--- a/test/unit/api/error_report_routing_test.dart
+++ b/test/unit/api/error_report_routing_test.dart
@@ -1,0 +1,130 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// api#94 — API log sites that report user misuse, invalid input, or
+// dropped/invalid data route through OTelErrorHandling.report() instead
+// of OTelLog.warn, so an installed error handler (or a factory default)
+// sees them. Per error-handling.md these are exactly the errors the
+// library suppresses "that would otherwise have been exposed to the
+// user"; a warn-level log line is not a substitute for the handler.
+//
+// Plain OTelLog.warn remains only for genuine advisories: this file also
+// pins the keep-decision for the empty provider-name fallback, which
+// coerces '' to the documented global default with nothing dropped.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('API error-class log sites route through the handler (api#94)', () {
+    late List<Object> reported;
+    late List<String> logged;
+
+    setUp(() {
+      OTelAPI.reset();
+      OTelAPI.initialize(
+        endpoint: 'http://localhost:4318',
+        serviceName: 'test-service',
+        serviceVersion: '1.0.0',
+      );
+      reported = [];
+      logged = [];
+      OTelLog.logFunction = (msg) => logged.add(msg);
+      OTelLog.currentLevel = LogLevel.warn;
+      OTelAPI.setErrorHandler((error, stackTrace) => reported.add(error));
+    });
+
+    tearDown(() {
+      OTelAPI.reset();
+      OTelLog.logFunction = print;
+      OTelLog.currentLevel = LogLevel.info;
+    });
+
+    test('a dropped attribute (unsupported value type) is reported', () {
+      // Attributes.of stringifies unknown scalar types by design; fromJson
+      // drops them — the drop must reach the handler.
+      final attrs = Attributes.fromJson({
+        'unsupported': {'nested': 'map'}
+      });
+
+      expect(attrs.toList(), isEmpty, reason: 'the attribute is dropped');
+      expect(reported, hasLength(1));
+      expect(reported.single, isArgumentError);
+      expect('${reported.single}', contains('unsupported'));
+      expect(logged, isEmpty,
+          reason: 'the report replaces the warn-level log line');
+    });
+
+    test('a dropped attribute (unsupported list element type) is reported', () {
+      final attrs = Attributes.of({
+        'mixed': [1, 'two']
+      });
+
+      expect(attrs.toList(), isEmpty, reason: 'the attribute is dropped');
+      expect(reported, hasLength(1));
+      expect(reported.single, isArgumentError);
+    });
+
+    test('an invalid (empty) tracer name is reported', () {
+      OTelAPI.tracerProvider().getTracer('');
+
+      expect(reported, hasLength(1));
+      expect(reported.single, isArgumentError);
+      expect(logged, isEmpty);
+    });
+
+    test('getTracer after shutdown is reported as a StateError', () async {
+      final provider = OTelAPI.tracerProvider();
+      await provider.shutdown();
+
+      provider.getTracer('post-shutdown');
+
+      expect(reported, hasLength(1));
+      expect(reported.single, isStateError);
+      expect(logged, isEmpty);
+    });
+
+    test('an invalid TraceState entry is reported and dropped', () {
+      final traceState = TraceState.empty().put('INVALID KEY', 'value');
+
+      expect(traceState.isEmpty, isTrue, reason: 'the entry is dropped');
+      expect(reported, hasLength(1));
+      expect(reported.single, isArgumentError);
+      expect(logged, isEmpty);
+    });
+
+    test('an empty baggage name is reported and the entry dropped', () {
+      final baggage = OTelAPI.baggage().copyWith('', 'value');
+
+      expect(baggage.getAllEntries(), isEmpty, reason: 'the entry is dropped');
+      expect(reported, hasLength(1));
+      expect(reported.single, isArgumentError);
+      expect(logged, isEmpty);
+    });
+
+    test('with no handler installed, reports log at error level', () {
+      OTelAPI.setErrorHandler(null);
+      OTelLog.currentLevel = LogLevel.error;
+
+      OTelAPI.tracerProvider().getTracer('');
+
+      expect(reported, isEmpty);
+      expect(logged, hasLength(1));
+      expect(logged.single, contains('ERROR'));
+      expect(logged.single, contains('Invalid tracer name'));
+    });
+
+    test('keep-decision: the empty provider-name fallback stays a warn', () {
+      // '' coerces to the documented global default; the returned provider
+      // is fully functional and nothing is dropped — a genuine advisory.
+      final provider = OTelAPI.tracerProvider('');
+
+      expect(provider, same(OTelAPI.tracerProvider()));
+      expect(reported, isEmpty,
+          reason: 'an informational fallback is not an error report');
+      expect(logged, hasLength(1));
+      expect(logged.single, contains('WARN'));
+      expect(logged.single, contains('global default'));
+    });
+  });
+}

--- a/test/unit/api/trace/span_link_test.dart
+++ b/test/unit/api/trace/span_link_test.dart
@@ -111,7 +111,7 @@ void main() {
       span.setStatus(SpanStatusCode.Error);
       expect(span.spanEvents, isNull);
       expect(span.status,
-          equals(SpanStatusCode.Ok)); // Status should remain unchanged
+          equals(SpanStatusCode.Unset)); // Status should remain unchanged
     });
 
     test('status setting rules', () {

--- a/test/unit/api/trace/span_test.dart
+++ b/test/unit/api/trace/span_test.dart
@@ -184,7 +184,8 @@ void main() {
       span.updateName('new-name');
 
       expect(span.attributes.length, equals(0));
-      expect(span.status, equals(SpanStatusCode.Ok));
+      // end() does not change the status; it stays Unset (trace/api.md)
+      expect(span.status, equals(SpanStatusCode.Unset));
       expect(span.statusDescription, isNull);
       expect(span.name, equals('test-span'));
     });
@@ -345,6 +346,7 @@ void main() {
     });
 
     test('addEvent throws if name is empty', () {
+      // NOTE: becomes non-throwing under api#69 (#119), a separate issue.
       final span = tracer.startSpan('test');
       expect(
         () => span.addEvent(OTelAPI.spanEvent('')),
@@ -356,7 +358,40 @@ void main() {
       final span = tracer.startSpan('test');
       span.end();
       span.end(); // Should not throw
-      expect(span.status, equals(SpanStatusCode.Ok));
+      expect(span.status, equals(SpanStatusCode.Unset));
+    });
+
+    test('end() leaves the status Unset', () {
+      // trace/api.md: End takes only an optional timestamp and never
+      // changes the status; only setStatus does.
+      final span = tracer.startSpan('test');
+      expect(span.status, equals(SpanStatusCode.Unset));
+      span.end();
+      expect(span.status, equals(SpanStatusCode.Unset));
+    });
+
+    test('end() preserves a status set before ending', () {
+      final span = tracer.startSpan('test');
+      span.setStatus(SpanStatusCode.Error, 'boom');
+      span.end();
+      expect(span.status, equals(SpanStatusCode.Error));
+      expect(span.statusDescription, equals('boom'));
+    });
+
+    test('end(spanStatus:) applies the setStatus rules, without an Ok default',
+        () {
+      // The deprecated spanStatus parameter still works but goes through
+      // setStatus; passing Unset is ignored per the Set Status rules.
+      final okSpan = tracer.startSpan('ok')..end(spanStatus: SpanStatusCode.Ok);
+      expect(okSpan.status, equals(SpanStatusCode.Ok));
+
+      final errorSpan = tracer.startSpan('error')
+        ..end(spanStatus: SpanStatusCode.Error);
+      expect(errorSpan.status, equals(SpanStatusCode.Error));
+
+      final unsetSpan = tracer.startSpan('unset')
+        ..end(spanStatus: SpanStatusCode.Unset);
+      expect(unsetSpan.status, equals(SpanStatusCode.Unset));
     });
 
     test('addEvent twice', () {
@@ -388,9 +423,9 @@ void main() {
       final span = tracer.startSpan('test');
       expect(span.status, equals(SpanStatusCode.Unset));
       span.end();
-      expect(span.status, equals(SpanStatusCode.Ok));
+      expect(span.status, equals(SpanStatusCode.Unset));
       span.setStatus(SpanStatusCode.Error);
-      expect(span.status, equals(SpanStatusCode.Ok));
+      expect(span.status, equals(SpanStatusCode.Unset));
     });
 
     test('recordException is ignored after end', () {

--- a/test/unit/factory/otel_factory_error_handler_test.dart
+++ b/test/unit/factory/otel_factory_error_handler_test.dart
@@ -1,0 +1,241 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// api#94 — the global error handler is factory-held state, like every
+// other global in this library:
+//
+// - [OTelFactory] holds the user-installed handler (an instance slot) and
+//   an overridable [OTelFactory.defaultErrorHandler] so SDK factories can
+//   supply their own default reporting behavior.
+// - [OTelErrorHandling.report] remains the single call-site API and
+//   resolves through [OTelFactory.otelFactory] when one is installed.
+// - Before any factory exists, [OTelAPI.setErrorHandler] buffers the
+//   handler and factory installation adopts it: never throw, never lose.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+/// A stand-in for an SDK factory that supplies its own default error
+/// handling behavior by overriding [defaultErrorHandler].
+class _OverridingDefaultFactory extends OTelAPIFactory {
+  _OverridingDefaultFactory()
+      : super(
+          apiEndpoint: 'http://localhost:4318',
+          apiServiceName: 'error-handler-test',
+          apiServiceVersion: '1.0.0',
+        );
+
+  final List<Object> defaultReports = <Object>[];
+
+  @override
+  OTelErrorHandler get defaultErrorHandler =>
+      (error, stackTrace) => defaultReports.add(error);
+}
+
+void main() {
+  group('factory-held error handler (api#94)', () {
+    late List<String> loggedMessages;
+
+    void initializeAPI() {
+      OTelAPI.initialize(
+        endpoint: 'http://localhost:4318',
+        serviceName: 'test-service',
+        serviceVersion: '1.0.0',
+      );
+    }
+
+    setUp(() {
+      OTelAPI.reset();
+      loggedMessages = [];
+      OTelLog.logFunction = (msg) => loggedMessages.add(msg);
+      OTelLog.currentLevel = LogLevel.error;
+    });
+
+    tearDown(() {
+      OTelAPI.reset();
+      OTelLog.logFunction = print;
+      OTelLog.currentLevel = LogLevel.info;
+    });
+
+    group('pre-init semantics — never throw, never lose', () {
+      test('setErrorHandler works before any factory is installed', () {
+        expect(OTelFactory.otelFactory, isNull);
+        expect(() => OTelAPI.setErrorHandler((error, stackTrace) {}),
+            returnsNormally);
+        expect(OTelFactory.otelFactory, isNull,
+            reason: 'setErrorHandler must not install a factory '
+                'as a side effect');
+      });
+
+      test('report() before any factory uses the buffered handler', () {
+        final received = <Object>[];
+        OTelAPI.setErrorHandler((error, stackTrace) => received.add(error));
+
+        OTelErrorHandling.report(ArgumentError('pre-init'));
+
+        expect(received, hasLength(1));
+        expect(loggedMessages, isEmpty,
+            reason: 'the buffered handler replaces the default logging');
+        expect(OTelFactory.otelFactory, isNull,
+            reason: 'report() must not install a factory as a side effect');
+      });
+
+      test('report() before any factory or handler logs via the default', () {
+        OTelErrorHandling.report(ArgumentError('pre-init default'));
+
+        expect(loggedMessages, hasLength(1));
+        expect(loggedMessages[0], contains('pre-init default'));
+        expect(OTelFactory.otelFactory, isNull,
+            reason: 'report() must not install a factory as a side effect');
+      });
+
+      test('factory installation adopts the buffered handler', () {
+        final received = <Object>[];
+        void bufferedHandler(Object error, StackTrace? stackTrace) =>
+            received.add(error);
+
+        OTelAPI.setErrorHandler(bufferedHandler);
+        initializeAPI();
+
+        expect(OTelErrorHandling.installedHandler, same(bufferedHandler));
+        expect(OTelFactory.otelFactory!.errorHandler, same(bufferedHandler),
+            reason: 'the installed factory holds the buffered handler');
+
+        OTelErrorHandling.report(StateError('post-install'));
+        expect(received, hasLength(1));
+        expect(loggedMessages, isEmpty);
+      });
+
+      test(
+          'a handler on the auto-installed no-op factory survives '
+          'explicit initialization', () {
+        // API use before initialize() lazily installs the no-op factory.
+        OTelFactory.getOrCreateDefault();
+        expect(OTelFactory.otelFactory!.isAPIFactory, isTrue);
+
+        final received = <Object>[];
+        void handler(Object error, StackTrace? stackTrace) =>
+            received.add(error);
+        OTelAPI.setErrorHandler(handler);
+
+        // Explicit initialization replaces the auto-installed factory;
+        // the user's handler must not be lost in the exchange.
+        initializeAPI();
+
+        expect(OTelErrorHandling.installedHandler, same(handler));
+        OTelErrorHandling.report(ArgumentError('after upgrade'));
+        expect(received, hasLength(1));
+      });
+    });
+
+    group('factory-held storage', () {
+      test('setErrorHandler stores the handler on the installed factory', () {
+        initializeAPI();
+        expect(OTelFactory.otelFactory!.errorHandler, isNull,
+            reason: 'no user handler is installed by default');
+
+        void handler(Object error, StackTrace? stackTrace) {}
+        OTelAPI.setErrorHandler(handler);
+
+        expect(OTelFactory.otelFactory!.errorHandler, same(handler));
+        expect(OTelErrorHandling.installedHandler, same(handler));
+      });
+
+      test('report() resolves through the factory-held handler', () {
+        initializeAPI();
+        final received = <Object>[];
+        OTelFactory.otelFactory!.errorHandler =
+            (error, stackTrace) => received.add(error);
+
+        OTelErrorHandling.report(ArgumentError('via the factory'));
+
+        expect(received, hasLength(1));
+        expect(loggedMessages, isEmpty);
+      });
+
+      test('setErrorHandler(null) clears the factory-held handler', () {
+        initializeAPI();
+        OTelAPI.setErrorHandler((error, stackTrace) {});
+
+        OTelAPI.setErrorHandler(null);
+
+        expect(OTelFactory.otelFactory!.errorHandler, isNull);
+        expect(OTelErrorHandling.installedHandler, isNull);
+        OTelErrorHandling.report(ArgumentError('back to default'));
+        expect(loggedMessages, hasLength(1));
+        expect(loggedMessages[0], contains('back to default'));
+      });
+
+      test('OTelAPI.reset() restores defaults', () {
+        initializeAPI();
+        final received = <Object>[];
+        OTelAPI.setErrorHandler((error, stackTrace) => received.add(error));
+
+        OTelAPI.reset();
+
+        expect(OTelErrorHandling.installedHandler, isNull);
+        OTelErrorHandling.report(ArgumentError('reset to default'));
+        expect(received, isEmpty);
+        expect(loggedMessages, hasLength(1));
+        expect(loggedMessages[0], contains('reset to default'));
+      });
+
+      test('OTelAPI.reset() clears a buffered pre-init handler', () {
+        final received = <Object>[];
+        OTelAPI.setErrorHandler((error, stackTrace) => received.add(error));
+
+        OTelAPI.reset();
+
+        expect(OTelErrorHandling.installedHandler, isNull);
+        OTelErrorHandling.report(ArgumentError('nothing buffered'));
+        expect(received, isEmpty);
+      });
+    });
+
+    group('factory subclass default (extensibility contract)', () {
+      test('a subclass default is used when no user handler is installed', () {
+        final factory = _OverridingDefaultFactory();
+        OTelFactory.otelFactory = factory;
+
+        OTelErrorHandling.report(ArgumentError('to the subclass default'));
+
+        expect(factory.defaultReports, hasLength(1));
+        expect(loggedMessages, isEmpty,
+            reason: 'the subclass default replaces the logging default');
+      });
+
+      test('a user-installed handler wins over the subclass default', () {
+        final factory = _OverridingDefaultFactory();
+        OTelFactory.otelFactory = factory;
+        final received = <Object>[];
+        OTelAPI.setErrorHandler((error, stackTrace) => received.add(error));
+
+        OTelErrorHandling.report(ArgumentError('to the user handler'));
+
+        expect(received, hasLength(1));
+        expect(factory.defaultReports, isEmpty);
+      });
+
+      test('setErrorHandler(null) returns to the subclass default', () {
+        final factory = _OverridingDefaultFactory();
+        OTelFactory.otelFactory = factory;
+        OTelAPI.setErrorHandler((error, stackTrace) {});
+
+        OTelAPI.setErrorHandler(null);
+        OTelErrorHandling.report(ArgumentError('back to the subclass'));
+
+        expect(factory.defaultReports, hasLength(1));
+        expect(loggedMessages, isEmpty);
+      });
+
+      test('the base default remains the logging handler', () {
+        initializeAPI();
+        expect(
+          OTelFactory.otelFactory!.defaultErrorHandler,
+          same(OTelErrorHandling.defaultErrorHandler),
+          reason: 'OTelAPIFactory does not override defaultErrorHandler',
+        );
+      });
+    });
+  });
+}

--- a/test/unit/util/otel_error_handler_test.dart
+++ b/test/unit/util/otel_error_handler_test.dart
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Spec-compliance tests for the global error handler
+// (error-handling.md, "Configuring Error Handlers"):
+//
+// > SDK implementations MUST allow end users to change the library's
+// > default error handling behavior for relevant errors.
+//
+// and for self-diagnostics:
+//
+// > Whenever the library suppresses an error that would otherwise have
+// > been exposed to the user, the library SHOULD log the error using
+// > language-specific conventions.
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OTelErrorHandling', () {
+    late List<String> loggedMessages;
+
+    setUp(() {
+      loggedMessages = [];
+      OTelLog.logFunction = (msg) => loggedMessages.add(msg);
+      OTelLog.currentLevel = LogLevel.error;
+      OTelErrorHandling.resetToDefault();
+    });
+
+    tearDown(() {
+      OTelLog.logFunction = print;
+      OTelLog.currentLevel = LogLevel.info;
+      OTelErrorHandling.resetToDefault();
+    });
+
+    test('default handler logs the error through OTelLog', () {
+      OTelErrorHandling.report(ArgumentError('bad input'));
+
+      expect(loggedMessages.length, equals(1));
+      expect(loggedMessages[0], contains('ERROR'));
+      expect(loggedMessages[0], contains('bad input'));
+    });
+
+    test('default handler logs the stack trace when one is given', () {
+      OTelErrorHandling.report(
+          StateError('broken'), StackTrace.fromString('fake stack'));
+
+      expect(loggedMessages.length, equals(2));
+      expect(loggedMessages[0], contains('broken'));
+      expect(loggedMessages[1], contains('Stack trace: fake stack'));
+    });
+
+    test('a user-installed handler receives reported errors', () {
+      final received = <Object>[];
+      final stacks = <StackTrace?>[];
+      OTelErrorHandling.handler = (error, stackTrace) {
+        received.add(error);
+        stacks.add(stackTrace);
+      };
+
+      final error = ArgumentError('invalid attribute');
+      final stack = StackTrace.current;
+      OTelErrorHandling.report(error, stack);
+
+      expect(received, equals([error]));
+      expect(stacks, equals([stack]));
+      expect(loggedMessages, isEmpty,
+          reason: 'a custom handler replaces the default logging');
+    });
+
+    test('the default handler never throws, even with logging disabled', () {
+      OTelLog.logFunction = null;
+      expect(() => OTelErrorHandling.report(ArgumentError('quiet')),
+          returnsNormally);
+    });
+
+    test('resetToDefault restores the logging handler', () {
+      OTelErrorHandling.handler = (error, stackTrace) {};
+      OTelErrorHandling.report(ArgumentError('swallowed'));
+      expect(loggedMessages, isEmpty);
+
+      OTelErrorHandling.resetToDefault();
+      OTelErrorHandling.report(ArgumentError('logged again'));
+      expect(loggedMessages.length, equals(1));
+      expect(loggedMessages[0], contains('logged again'));
+    });
+
+    test('a rethrowing handler makes invalid usage fail fast', () {
+      // The staging-environment use case called out by the spec: the one
+      // sanctioned exception to "never throw".
+      OTelErrorHandling.handler = (error, stackTrace) =>
+          Error.throwWithStackTrace(error, stackTrace ?? StackTrace.current);
+
+      expect(() => OTelErrorHandling.report(ArgumentError('strict mode')),
+          throwsArgumentError);
+    });
+
+    test('OTelAPI.setErrorHandler installs and clears the handler', () {
+      final received = <Object>[];
+      OTelAPI.setErrorHandler((error, stackTrace) => received.add(error));
+
+      OTelErrorHandling.report(ArgumentError('via OTelAPI'));
+      expect(received.length, equals(1));
+      expect(loggedMessages, isEmpty);
+
+      OTelAPI.setErrorHandler(null);
+      OTelErrorHandling.report(ArgumentError('back to default'));
+      expect(received.length, equals(1));
+      expect(loggedMessages.length, equals(1));
+      expect(loggedMessages[0], contains('back to default'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First set from the wave-2 spec-compliance worklist (#101): the **error-handling foundation plus two P0 propagation primitives**. One commit per issue.

- **api#94** — adds a user-configurable global error handler: `OTelAPI.setErrorHandler(handler)` / `OTelErrorHandling.handler`, default logs via `OTelLog` and never throws. Per [error-handling.md](https://opentelemetry.io/docs/specs/otel/error-handling/), API misuse must not crash the app; later no-throw fixes route their reports through this. A user-installed handler that throws propagates deliberately (the spec's strict-mode exception).
- **api#60** — `Span.end()` no longer promotes status `Unset` → `Ok`. [trace/api.md — Set Status](https://opentelemetry.io/docs/specs/otel/trace/api/#set-status): `Ok` is final and must be an explicit developer choice; fabricating it masks errors from analysis tools. The deprecated `spanStatus` parameter still flows through the `setStatus` rules when passed.
- **api#76** — `CompositePropagator.extract` now walks propagators **in the order they were specified** ([context/api-propagators.md — Composite](https://opentelemetry.io/docs/specs/otel/context/api-propagators/#composite-propagator)); it was reversed, silently making the last-registered propagator win extraction, opposite to every other OpenTelemetry SDK.
- **api#77** — `Context.withSpanContext` returns a derived `Context` instead of throwing `ArgumentError` when the context already holds a span from a different trace — a routine situation on the extract path; Extract must never throw.

**Factory-held design (maintainer-directed):** the handler lives in `OTelFactory` — an instance slot plus an overridable `defaultErrorHandler` getter, so factory subclasses extend error handling like everything else; a factory can also reconstruct its own handler natively in `deserialize()`, making the isolate handshake unnecessary for it. `OTelAPI.setErrorHandler` is unchanged for users and works pre-init (buffered, adopted at factory install; a replaced factory's user handler carries to its replacement). The API's own error-class report sites now route through the handler too (13 rerouted, 3 kept as informational — each keep justified in the commit body).

**Isolate propagation (red→green pair on top):** the handler registry is a per-isolate static, so `Context.runIsolate` — the seam that already re-establishes the factory and context in the child — now re-installs the parent's handler there too, via an explicit port handshake. Handlers are *copied* into the child: logging/reporting handlers behave identically; to aggregate reports in the parent, capture a `SendPort` (the docs and tests show the pattern — capturing the `ReceivePort`, even implicitly via `received.sendPort` inside the closure, is unsendable). An unsendable handler degrades to the child default and reports the degradation through the parent's handler instead of failing the spawn. Manually-spawned isolates (not via `runIsolate`) still need their own install.

## Behavioral notes

- `end()` behavior change: spans that never set a status now export `Unset` (previously `Ok`). Backends treating `Unset` as "no opinion" — the spec's intent — are unaffected.
- Composite extract order change is observable only when multiple propagators write the same context slot.

CHANGELOG entries included.

## Structure — wave TDD convention (#44)

Each behavior fix is **two commits: red then green** — the first pins the spec contract with failing tests, the second makes them pass. Verified per commit: the red commits fail exactly their pinned contracts (1, 2, and 5 failures respectively) and every green commit passes.

api#94 is the exception, deliberately: it introduces new API surface, so contract tests cannot compile before the class exists — the convention's fix-needs-design carve-out; it lands as one feature+tests commit.

## Testing

- New/updated unit tests per issue: handler install/reset/report semantics; Unset-preserved, Error-preserved, deprecated-parameter path on `end()`; composite order (last-registered wins on a shared slot); derived-context extraction cases replacing the old throw assertions.
- Full suite green (1,133 tests); `dart analyze` clean; `dart format` clean.
- One cherry-pick note for reviewers: the `addEvent` empty-name test keeps today's throwing behavior — making it non-throwing is api#69, deliberately not in this set.

Fixes #94, fixes #60, fixes #76, fixes #77.

> Maintainer-reviewed AI-assisted change: implementation drafted with Claude, reviewed, tested, and submitted under maintainer ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
