### PR TITLE
fix(api): store empty string and empty array attribute values per OTel spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ fixes. See the `1.0.0-rc.3` entry for detail.
   schema URL. Both are `null` when you omit them.
   ([#108](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/108))
 
+### Fixed (spec compliance)
+- **Empty string and empty array attribute values are now stored** (api#80).
+  The OTel specification requires that empty strings and empty arrays be
+  valid attribute values. Previously `attributeString('k', '')` and
+  `attributeStringList('k', [])` threw `ArgumentError`, and
+  `Attributes.fromJson` silently dropped empty lists. Now all three paths
+  store empty values correctly.
+
 ## [1.0.0-rc.2] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `OTelAPI.spanEvent('')`, `addEvent`, `addEventNow` and `addEvents` no longer
   throw an `ArgumentError`, per error-handling.md
   ([#117](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/117)).
+- Empty string and empty array attribute values no longer throw `ArgumentError`
+  ([#103](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/103)).
 
 ## [1.0.0-rc.3] - 2026-08-27
 
@@ -56,14 +58,6 @@ fixes. See the `1.0.0-rc.3` entry for detail.
 - `getTracer`, `getLogger` and `getMeter` no longer invent a scope version or
   schema URL. Both are `null` when you omit them.
   ([#108](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/108))
-
-### Fixed (spec compliance)
-- **Empty string and empty array attribute values are now stored** (api#80).
-  The OTel specification requires that empty strings and empty arrays be
-  valid attribute values. Previously `attributeString('k', '')` and
-  `attributeStringList('k', [])` threw `ArgumentError`, and
-  `Attributes.fromJson` silently dropped empty lists. Now all three paths
-  store empty values correctly.
 
 ## [1.0.0-rc.2] - 2026-08-23
 

--- a/lib/src/api/common/attribute.dart
+++ b/lib/src/api/common/attribute.dart
@@ -22,20 +22,7 @@ class Attribute<T extends Object> {
 
   Attribute._(String key, T value)
       : _key = key,
-        _value = value {
-    if (_value is String && (_value as String).isEmpty) {
-      throw ArgumentError('Attribute _value must not be an empty string');
-    }
-    if (_value is List) {
-      final valueList = _value as List;
-      if (valueList.isEmpty) {
-        throw ArgumentError('Attribute _value list must not be empty');
-      }
-      // No null-element guard: attributes are only created with
-      // non-nullable element types (List<String>, List<bool>, List<int>,
-      // List<double>), so sound null safety already rules nulls out.
-    }
-  }
+        _value = value;
 
   /// Gets the key (name) of this attribute.
   String get key => _key;

--- a/lib/src/api/common/attributes.dart
+++ b/lib/src/api/common/attributes.dart
@@ -54,31 +54,28 @@ class Attributes {
       } else if (value is List<double>) {
         attributes.add(AttributeCreate.create<List<double>>(key, value));
       } else if (value is List) {
-        // Try to convert the list to a supported type
-        if (value.isNotEmpty) {
-          if (value.every((e) => e is String)) {
-            attributes.add(AttributeCreate.create<List<String>>(
-                key, value.cast<String>()));
-          } else if (value.every((e) => e is bool)) {
-            attributes.add(
-                AttributeCreate.create<List<bool>>(key, value.cast<bool>()));
-          } else if (value.every((e) => e is int)) {
-            attributes
-                .add(AttributeCreate.create<List<int>>(key, value.cast<int>()));
-          } else if (value.every((e) => e is double || e is int)) {
-            // Convert all to double
-            attributes.add(AttributeCreate.create<List<double>>(
-                key,
-                value
-                    .map((e) => e is int ? e.toDouble() : e as double)
-                    .toList()));
-          } else {
-            OTelErrorHandling.report(ArgumentError(
-                'Ignoring attribute $key because the list contains unsupported types. Only String, bool, int, double lists are allowed by the OTel specification.'));
-          }
+        // Try to convert the list to a supported type.
+        // For empty lists, .every() returns true for all predicates,
+        // so String wins by position — a reasonable default.
+        if (value.every((e) => e is String)) {
+          attributes.add(
+              AttributeCreate.create<List<String>>(key, value.cast<String>()));
+        } else if (value.every((e) => e is bool)) {
+          attributes
+              .add(AttributeCreate.create<List<bool>>(key, value.cast<bool>()));
+        } else if (value.every((e) => e is int)) {
+          attributes
+              .add(AttributeCreate.create<List<int>>(key, value.cast<int>()));
+        } else if (value.every((e) => e is double || e is int)) {
+          // Convert all to double
+          attributes.add(AttributeCreate.create<List<double>>(
+              key,
+              value
+                  .map((e) => e is int ? e.toDouble() : e as double)
+                  .toList()));
         } else {
           OTelErrorHandling.report(ArgumentError(
-              'Ignoring attribute $key because empty lists are not allowed by the OTel specification.'));
+              'Ignoring attribute $key because the list contains unsupported types. Only String, bool, int, double lists are allowed by the OTel specification.'));
         }
       } else {
         OTelErrorHandling.report(ArgumentError(
@@ -324,7 +321,7 @@ class Attributes {
 /// Extension to create Attributes from a simple Map
 extension AttributesExtension on Map<String, Object> {
   /// Convert this map to Attributes
-  /// Empty string are not allowed and are skipped
+  /// Empty strings and empty lists are stored per the OTel spec
   Attributes toAttributes() {
     return OTelFactory.getOrCreateDefault().attributesFromMap(this);
   }

--- a/lib/src/api/common/attributes.dart
+++ b/lib/src/api/common/attributes.dart
@@ -54,9 +54,9 @@ class Attributes {
       } else if (value is List<double>) {
         attributes.add(AttributeCreate.create<List<double>>(key, value));
       } else if (value is List) {
-        // Try to convert the list to a supported type.
-        // For empty lists, .every() returns true for all predicates,
-        // so String wins by position — a reasonable default.
+        // Untyped lists (List<Object> / List<dynamic>): element-check
+        // rather than hard-cast.  Empty untyped lists take the
+        // List<String> fallback because .every() is vacuously true.
         if (value.every((e) => e is String)) {
           attributes.add(
               AttributeCreate.create<List<String>>(key, value.cast<String>()));

--- a/lib/src/api/common/attributes.dart
+++ b/lib/src/api/common/attributes.dart
@@ -75,7 +75,7 @@ class Attributes {
                   .toList()));
         } else {
           OTelErrorHandling.report(ArgumentError(
-              'Ignoring attribute $key because the list contains unsupported types. Only String, bool, int, double lists are allowed by the OTel specification.'));
+              'Ignoring attribute $key because the list contains unsupported types. Only lists of Strings, bools, ints and doubles are allowed by the OTel specification.'));
         }
       } else {
         OTelErrorHandling.report(ArgumentError(

--- a/lib/src/api/factory/otel_api_factory.dart
+++ b/lib/src/api/factory/otel_api_factory.dart
@@ -161,7 +161,7 @@ class OTelAPIFactory extends OTelFactory {
   /// Creates Attributes from a map of string keys to arbitrary values.
   ///
   /// This method handles converting various value types to appropriate attribute values:
-  /// - String values become string attributes (empty strings are ignored)
+  /// - String values become string attributes (empty strings are stored per the OTel spec)
   /// - int, double, and bool values become their respective attribute types
   /// - DateTime values are converted to ISO8601 string attributes
   /// - Attribute values are passed through directly
@@ -171,9 +171,7 @@ class OTelAPIFactory extends OTelFactory {
     final attributes = <Attribute>[];
     namedMap.forEach((key, value) {
       if (value is String) {
-        if (value.isNotEmpty) {
-          attributes.add(AttributeCreate.create<String>(key, value));
-        }
+        attributes.add(AttributeCreate.create<String>(key, value));
       } else if (value is int) {
         attributes.add(AttributeCreate.create<int>(key, value));
       } else if (value is double) {
@@ -189,27 +187,25 @@ class OTelAPIFactory extends OTelFactory {
         // Element-check rather than hard-cast: the static list type is
         // often List<Object> or List<dynamic> (e.g. from map literals),
         // which `as List<String>` would reject at runtime.
-        if (value.isNotEmpty) {
-          if (value.every((e) => e is String)) {
-            attributes.add(AttributeCreate.create<List<String>>(
-                key, value.cast<String>()));
-          } else if (value.every((e) => e is bool)) {
-            attributes.add(
-                AttributeCreate.create<List<bool>>(key, value.cast<bool>()));
-          } else if (value.every((e) => e is int)) {
-            attributes
-                .add(AttributeCreate.create<List<int>>(key, value.cast<int>()));
-          } else if (value.every((e) => e is double || e is int)) {
-            // Mixed numeric lists are promoted to double.
-            attributes.add(AttributeCreate.create<List<double>>(
-                key,
-                value
-                    .map((e) => e is int ? e.toDouble() : e as double)
-                    .toList()));
-          } else {
-            OTelErrorHandling.report(ArgumentError(
-                'Ignoring attribute $key because the list contains unsupported types. Only String, bool, int, double lists are allowed by the OTel specification.'));
-          }
+        if (value.every((e) => e is String)) {
+          attributes.add(
+              AttributeCreate.create<List<String>>(key, value.cast<String>()));
+        } else if (value.every((e) => e is bool)) {
+          attributes
+              .add(AttributeCreate.create<List<bool>>(key, value.cast<bool>()));
+        } else if (value.every((e) => e is int)) {
+          attributes
+              .add(AttributeCreate.create<List<int>>(key, value.cast<int>()));
+        } else if (value.every((e) => e is double || e is int)) {
+          // Mixed numeric lists are promoted to double.
+          attributes.add(AttributeCreate.create<List<double>>(
+              key,
+              value
+                  .map((e) => e is int ? e.toDouble() : e as double)
+                  .toList()));
+        } else {
+          OTelErrorHandling.report(ArgumentError(
+              'Ignoring attribute $key because the list contains unsupported types. Only String, bool, int, double lists are allowed by the OTel specification.'));
         }
       } else {
         attributes.add(AttributeCreate.create<String>(key, '$value'));

--- a/lib/src/api/factory/otel_api_factory.dart
+++ b/lib/src/api/factory/otel_api_factory.dart
@@ -183,10 +183,18 @@ class OTelAPIFactory extends OTelFactory {
         attributes.add(AttributeCreate.create<String>(key, isoTimestamp));
       } else if (value is Attribute) {
         attributes.add(value);
+      } else if (value is List<String>) {
+        attributes.add(AttributeCreate.create<List<String>>(key, value));
+      } else if (value is List<bool>) {
+        attributes.add(AttributeCreate.create<List<bool>>(key, value));
+      } else if (value is List<int>) {
+        attributes.add(AttributeCreate.create<List<int>>(key, value));
+      } else if (value is List<double>) {
+        attributes.add(AttributeCreate.create<List<double>>(key, value));
       } else if (value is List) {
-        // Element-check rather than hard-cast: the static list type is
-        // often List<Object> or List<dynamic> (e.g. from map literals),
-        // which `as List<String>` would reject at runtime.
+        // Untyped lists (List<Object> / List<dynamic>): element-check
+        // rather than hard-cast.  Empty untyped lists take the
+        // List<String> fallback because .every() is vacuously true.
         if (value.every((e) => e is String)) {
           attributes.add(
               AttributeCreate.create<List<String>>(key, value.cast<String>()));

--- a/test/unit/api/common/attribute_test.dart
+++ b/test/unit/api/common/attribute_test.dart
@@ -66,23 +66,19 @@ void main() {
         expect(doubleList.hashCode, isNot(equals(doubleList2.hashCode)));
       });
 
-      test('empty collections throw ArgumentError', () {
-        expect(
-          () => OTelAPI.attributeStringList('foo', []),
-          throwsArgumentError,
-        );
-        expect(
-          () => OTelAPI.attributeIntList('foo', []),
-          throwsArgumentError,
-        );
-        expect(
-          () => OTelAPI.attributeBoolList('foo', []),
-          throwsArgumentError,
-        );
-        expect(
-          () => OTelAPI.attributeDoubleList('foo', []),
-          throwsArgumentError,
-        );
+      test('empty collections are stored per OTel spec', () {
+        final stringList = OTelAPI.attributeStringList('foo', []);
+        expect(stringList.value, equals([]));
+        expect(stringList.key, equals('foo'));
+
+        final intList = OTelAPI.attributeIntList('foo', []);
+        expect(intList.value, equals([]));
+
+        final boolList = OTelAPI.attributeBoolList('foo', []);
+        expect(boolList.value, equals([]));
+
+        final doubleList = OTelAPI.attributeDoubleList('foo', []);
+        expect(doubleList.value, equals([]));
       });
     });
   });

--- a/test/unit/api/common/attribute_validation_test.dart
+++ b/test/unit/api/common/attribute_validation_test.dart
@@ -85,9 +85,15 @@ void main() {
       expect(attrs.getString('key'), equals(''));
     });
 
-    test('Attributes.of preserves typed empty list', () {
-      final attrs = Attributes.of({'key': <String>[]});
-      expect(attrs.getStringList('key'), equals(<String>[]));
+    test('Attributes.of preserves the element type of typed empty lists', () {
+      expect(
+          Attributes.of({'k': <String>[]}).getStringList('k'), equals(<String>[]));
+      expect(
+          Attributes.of({'k': <bool>[]}).getBoolList('k'), equals(<bool>[]));
+      expect(
+          Attributes.of({'k': <int>[]}).getIntList('k'), equals(<int>[]));
+      expect(Attributes.of({'k': <double>[]}).getDoubleList('k'),
+          equals(<double>[]));
     });
 
     test('Attributes.of preserves untyped empty list as List<String>', () {

--- a/test/unit/api/common/attribute_validation_test.dart
+++ b/test/unit/api/common/attribute_validation_test.dart
@@ -18,13 +18,16 @@ void main() {
       );
     });
 
-    test('empty string value throws', () {
-      expect(() => OTelAPI.attributeString('k', ''), throwsArgumentError);
+    test('empty string value is stored', () {
+      final attr = OTelAPI.attributeString('k', '');
+      expect(attr.value, equals(''));
+      expect(attr.key, equals('k'));
     });
 
-    test('empty list value throws', () {
-      expect(() => OTelAPI.attributeStringList('k', <String>[]),
-          throwsArgumentError);
+    test('empty list value is stored', () {
+      final attr = OTelAPI.attributeStringList('k', <String>[]);
+      expect(attr.value, equals(<String>[]));
+      expect(attr.key, equals('k'));
     });
 
     test('toString includes the value', () {
@@ -75,6 +78,35 @@ void main() {
       expect(attrs.getBoolList('flags'), equals([true, false]));
       expect(attrs.getIntList('counts'), equals([1, 2]));
       expect(attrs.getDoubleList('nums'), equals([1.0, 2.5]));
+    });
+
+    test('Attributes.of preserves empty string', () {
+      final attrs = Attributes.of({'key': ''});
+      expect(attrs.getString('key'), equals(''));
+    });
+
+    test('Attributes.of preserves typed empty list', () {
+      final attrs = Attributes.of({'key': <String>[]});
+      expect(attrs.getStringList('key'), equals(<String>[]));
+    });
+
+    test('Attributes.of preserves untyped empty list as List<String>', () {
+      final attrs = Attributes.of({'key': <Object>[]});
+      expect(attrs.getStringList('key'), equals(<String>[]));
+    });
+
+    test('empty list attribute equality', () {
+      final a = OTelAPI.attributeStringList('k', []);
+      final b = OTelAPI.attributeStringList('k', []);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('empty string attribute equality', () {
+      final a = OTelAPI.attributeString('k', '');
+      final b = OTelAPI.attributeString('k', '');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
     });
   });
 }

--- a/test/unit/api/common/attribute_validation_test.dart
+++ b/test/unit/api/common/attribute_validation_test.dart
@@ -86,12 +86,10 @@ void main() {
     });
 
     test('Attributes.of preserves the element type of typed empty lists', () {
-      expect(
-          Attributes.of({'k': <String>[]}).getStringList('k'), equals(<String>[]));
-      expect(
-          Attributes.of({'k': <bool>[]}).getBoolList('k'), equals(<bool>[]));
-      expect(
-          Attributes.of({'k': <int>[]}).getIntList('k'), equals(<int>[]));
+      expect(Attributes.of({'k': <String>[]}).getStringList('k'),
+          equals(<String>[]));
+      expect(Attributes.of({'k': <bool>[]}).getBoolList('k'), equals(<bool>[]));
+      expect(Attributes.of({'k': <int>[]}).getIntList('k'), equals(<int>[]));
       expect(Attributes.of({'k': <double>[]}).getDoubleList('k'),
           equals(<double>[]));
     });

--- a/test/unit/api/common/attributes_test.dart
+++ b/test/unit/api/common/attributes_test.dart
@@ -481,12 +481,28 @@ void main() {
       expect(attrs.getDoubleList('key'), equals([1.0, 2.5, 3.0]));
     });
 
-    test('fromJson ignores empty list with warning', () {
+    test('fromJson stores empty list per OTel spec', () {
       final json = <String, dynamic>{'key': <dynamic>[]};
       final attrs = Attributes.fromJson(json);
 
-      // Empty lists are ignored per OTel spec
-      expect(attrs.isEmpty, isTrue);
+      // Empty lists are stored per the OTel spec: they are meaningful values.
+      expect(attrs.isEmpty, isFalse);
+      expect(attrs.getStringList('key'), equals(<String>[]));
+    });
+
+    test('fromJson round-trips empty string and empty list', () {
+      final json = <String, dynamic>{
+        'emptyStr': '',
+        'emptyList': <String>[],
+      };
+      final attrs = Attributes.fromJson(json);
+
+      expect(attrs.getString('emptyStr'), equals(''));
+      expect(attrs.getStringList('emptyList'), equals(<String>[]));
+
+      final roundTripped = Attributes.fromJson(attrs.toJson());
+      expect(roundTripped.getString('emptyStr'), equals(''));
+      expect(roundTripped.getStringList('emptyList'), equals(<String>[]));
     });
 
     test('fromJson ignores unsupported list types with warning', () {

--- a/test/unit/api/common/attributes_test.dart
+++ b/test/unit/api/common/attributes_test.dart
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'dart:convert';
+
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
 
@@ -500,9 +502,22 @@ void main() {
       expect(attrs.getString('emptyStr'), equals(''));
       expect(attrs.getStringList('emptyList'), equals(<String>[]));
 
-      final roundTripped = Attributes.fromJson(attrs.toJson());
+      final decoded = jsonDecode(jsonEncode(attrs.toJson())) as Map<String, dynamic>;
+      final roundTripped = Attributes.fromJson(decoded);
       expect(roundTripped.getString('emptyStr'), equals(''));
       expect(roundTripped.getStringList('emptyList'), equals(<String>[]));
+    });
+
+    test('empty typed list loses element type through real JSON round-trip', () {
+      final attrs = Attributes.of({'k': <int>[]});
+      expect(attrs.getIntList('k'), equals(<int>[]));
+
+      final decoded = jsonDecode(jsonEncode(attrs.toJson())) as Map<String, dynamic>;
+      final roundTripped = Attributes.fromJson(decoded);
+
+      // JSON has no element-type information, so the empty list comes back
+      // as List<dynamic> and falls through to the List<String> fallback.
+      expect(roundTripped.getStringList('k'), equals(<String>[]));
     });
 
     test('fromJson ignores unsupported list types with warning', () {

--- a/test/unit/api/common/attributes_test.dart
+++ b/test/unit/api/common/attributes_test.dart
@@ -502,17 +502,20 @@ void main() {
       expect(attrs.getString('emptyStr'), equals(''));
       expect(attrs.getStringList('emptyList'), equals(<String>[]));
 
-      final decoded = jsonDecode(jsonEncode(attrs.toJson())) as Map<String, dynamic>;
+      final decoded =
+          jsonDecode(jsonEncode(attrs.toJson())) as Map<String, dynamic>;
       final roundTripped = Attributes.fromJson(decoded);
       expect(roundTripped.getString('emptyStr'), equals(''));
       expect(roundTripped.getStringList('emptyList'), equals(<String>[]));
     });
 
-    test('empty typed list loses element type through real JSON round-trip', () {
+    test('empty typed list loses element type through real JSON round-trip',
+        () {
       final attrs = Attributes.of({'k': <int>[]});
       expect(attrs.getIntList('k'), equals(<int>[]));
 
-      final decoded = jsonDecode(jsonEncode(attrs.toJson())) as Map<String, dynamic>;
+      final decoded =
+          jsonDecode(jsonEncode(attrs.toJson())) as Map<String, dynamic>;
       final roundTripped = Attributes.fromJson(decoded);
 
       // JSON has no element-type information, so the empty list comes back


### PR DESCRIPTION
## What

Fixes #80. Empty string and empty array attribute values are now stored instead of throwing or being silently dropped.

## Why

The OTel specification ([Common Specification, v1.60.0](https://opentelemetry.io/docs/specs/otel/common/#attribute)) requires:

> AnyValues expressing an empty value, a numerical value of zero, an empty string, or an empty array are considered meaningful and MUST be stored and passed on to processors / exporters.

Previously:
- `OTelAPI.attributeString('k', '')` threw `ArgumentError`
- `OTelAPI.attributeStringList('k', [])` threw `ArgumentError`
- `Attributes.fromJson({'key': []})` silently dropped the empty list
- `Attributes.of({'key': []})` silently dropped the empty list

## Changes

### Source
- **`attribute.dart`**: Removed the two throw blocks in `Attribute._()` that rejected empty strings and empty lists.
- **`otel_api_factory.dart`**: Removed `value.isNotEmpty` guards on string and list values in `attrsFromMap`. Empty values now flow through to the constructor normally. Updated doc comment.
- **`attributes.dart`**: Removed the `value.isNotEmpty` guard and the empty-list `report()` branch in `fromJson`. Untyped empty lists now default to `List<String>` (since `.every()` returns `true` for all predicates). Updated doc comment.

### Tests
- Flipped 4 existing tests that encoded the buggy behavior (2 in `attribute_validation_test.dart`, 1 in `attribute_test.dart`, 1 in `attributes_test.dart`).
- Added 6 new regression tests: empty string stored, empty typed list stored, empty untyped list stored as `List<String>`, empty list equality, empty string equality, and `fromJson` round-trip for empty values.

### Documentation
- Added CHANGELOG entry under `[1.0.0-rc.3-wip]`.

## Verification

- `dart analyze --fatal-infos` — 0 issues
- `dart test` — 1176/1176 pass
- Reproduction script confirms all 5 empty-value cases now store correctly instead of throwing

## Scope

No behavioral change for non-empty values. The only change is that empty strings and empty lists are now accepted and stored, which aligns with the OTel spec requirement.
