### PR TITLE
fix: replace enabled getter with isEnabled() method across Trace, Logs, and Metrics APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-rc.3-wip]
 
+### Changed
+- **BREAKING**: Replaced the `enabled` getter with `isEnabled()` method on `APITracer`, `APILogger`, `APIInstrument` and all instrument subclasses. The `enabled` parameter has also been removed from all metric instrument creation API constructors and factories. This change allows SDKs to dynamically re-evaluate instrument enablement and enables adding parameters to `isEnabled()` in the future without breaking the API.
+
 ## [1.0.0-rc.2] - 2026-08-23
 
 ### Added

--- a/lib/src/api/factory/otel_api_factory.dart
+++ b/lib/src/api/factory/otel_api_factory.dart
@@ -382,7 +382,6 @@ class OTelAPIFactory extends OTelFactory {
       name: name,
       description: description,
       unit: unit,
-      enabled: false, // API implementation is always disabled
       meter: APIMeterCreate.create(name: '@api/default'),
     );
   }
@@ -394,7 +393,6 @@ class OTelAPIFactory extends OTelFactory {
       name: name,
       description: description,
       unit: unit,
-      enabled: false, // API implementation is always disabled
       meter: APIMeterCreate.create(name: '@api/default'),
     );
   }
@@ -405,7 +403,6 @@ class OTelAPIFactory extends OTelFactory {
       name: name,
       description: description,
       unit: unit,
-      enabled: false, // API implementation is always disabled
       meter: APIMeterCreate.create(name: '@api/default'),
     );
   }
@@ -417,7 +414,6 @@ class OTelAPIFactory extends OTelFactory {
       name: name,
       description: description,
       unit: unit,
-      enabled: false, // API implementation is always disabled
       meter: APIMeterCreate.create(name: '@api/default'),
       boundaries: boundaries,
     );
@@ -430,7 +426,6 @@ class OTelAPIFactory extends OTelFactory {
       name: name,
       description: description,
       unit: unit,
-      enabled: false, // API implementation is always disabled
       meter: APIMeterCreate.create(name: '@api/default'),
       callback: callback,
     );
@@ -443,7 +438,6 @@ class OTelAPIFactory extends OTelFactory {
       name: name,
       description: description,
       unit: unit,
-      enabled: false, // API implementation is always disabled
       meter: APIMeterCreate.create(name: '@api/default'),
       callback: callback,
     );
@@ -456,7 +450,6 @@ class OTelAPIFactory extends OTelFactory {
       name: name,
       description: description,
       unit: unit,
-      enabled: false, // API implementation is always disabled
       meter: APIMeterCreate.create(name: '@api/default'),
       callback: callback,
     );

--- a/lib/src/api/logs/logger.dart
+++ b/lib/src/api/logs/logger.dart
@@ -37,9 +37,20 @@ class APILogger {
     this.attributes,
   });
 
-  /// Returns true if the logger is enabled.
+  /// Returns whether this logger is enabled for the provided arguments.
   /// Refer https://opentelemetry.io/docs/specs/otel/logs/api/#enabled
-  bool get enabled => false;
+  ///
+  /// The returned value can change over time; instrumentation authors need
+  /// to call this each time before emitting a LogRecord to ensure they have
+  /// the most up-to-date response.
+  ///
+  /// [context] The Context to associate with a would-be LogRecord. Defaults
+  /// to the current Context when unspecified, per the spec.
+  /// [severityNumber] The optional Severity Number of a would-be LogRecord.
+  /// [eventName] The optional Event Name of a would-be LogRecord.
+  bool isEnabled(
+          {Context? context, Severity? severityNumber, String? eventName}) =>
+      false;
 
   /// Emit a LogRecord.
   ///

--- a/lib/src/api/metrics/counter.dart
+++ b/lib/src/api/metrics/counter.dart
@@ -21,9 +21,6 @@ class APICounter<T extends num> {
   /// The optional unit of measure for this counter instrument.
   final String? _unit;
 
-  /// Whether this counter is enabled for recording measurements.
-  final bool _enabled;
-
   /// The meter that created this counter instrument.
   final APIMeter _meter;
 
@@ -34,13 +31,11 @@ class APICounter<T extends num> {
   /// [_name] The name of the counter instrument.
   /// [_description] Optional description of the counter instrument.
   /// [_unit] Optional unit of measurement for the counter.
-  /// [_enabled] Whether this counter is enabled for recording measurements.
   /// [_meter] The meter that created this counter instrument.
   APICounter(
     this._name,
     this._description,
     this._unit,
-    this._enabled,
     this._meter,
   );
 
@@ -53,8 +48,13 @@ class APICounter<T extends num> {
   /// Returns the unit of this Counter.
   String? get unit => _unit;
 
-  /// Returns whether this counter is enabled.
-  bool get enabled => _enabled;
+  /// Returns whether the instrument is enabled and will record measurements.
+  ///
+  /// The returned value can change over time; instrumentation authors need
+  /// to call this before each measurement to ensure they have the most
+  /// up-to-date response. The base API implementation always returns false;
+  /// SDK subclasses override this to compute the real, current value.
+  bool isEnabled() => false;
 
   /// Returns the meter that created this counter.
   APIMeter get meter => _meter;

--- a/lib/src/api/metrics/counter_create.dart
+++ b/lib/src/api/metrics/counter_create.dart
@@ -14,14 +14,12 @@ class CounterCreate {
     required String name,
     String? unit,
     String? description,
-    required bool enabled,
     required APIMeter meter,
   }) {
     return APICounter<T>(
       name,
       description,
       unit,
-      enabled,
       meter,
     );
   }

--- a/lib/src/api/metrics/gauge.dart
+++ b/lib/src/api/metrics/gauge.dart
@@ -21,9 +21,6 @@ class APIGauge<T extends num> {
   /// The optional unit of measure for this gauge instrument.
   final String? _unit;
 
-  /// Whether this gauge is enabled for recording measurements.
-  final bool _enabled;
-
   /// The meter that created this gauge instrument.
   final APIMeter _meter;
 
@@ -34,13 +31,11 @@ class APIGauge<T extends num> {
   /// [_name] The name of the gauge instrument.
   /// [_description] Optional description of the gauge instrument.
   /// [_unit] Optional unit of measurement for the gauge.
-  /// [_enabled] Whether this gauge is enabled for recording measurements.
   /// [_meter] The meter that created this gauge instrument.
   APIGauge(
     this._name,
     this._description,
     this._unit,
-    this._enabled,
     this._meter,
   );
 
@@ -53,8 +48,13 @@ class APIGauge<T extends num> {
   /// Returns the unit of this Gauge.
   String? get unit => _unit;
 
-  /// Returns whether this gauge is enabled.
-  bool get enabled => _enabled;
+  /// Returns whether the instrument is enabled and will record measurements.
+  ///
+  /// The returned value can change over time; instrumentation authors need
+  /// to call this before each measurement to ensure they have the most
+  /// up-to-date response. The base API implementation always returns false;
+  /// SDK subclasses override this to compute the real, current value.
+  bool isEnabled() => false;
 
   /// Returns the meter that created this gauge.
   APIMeter get meter => _meter;

--- a/lib/src/api/metrics/gauge_create.dart
+++ b/lib/src/api/metrics/gauge_create.dart
@@ -14,14 +14,12 @@ class GaugeCreate {
     required String name,
     String? unit,
     String? description,
-    required bool enabled,
     required APIMeter meter,
   }) {
     return APIGauge<T>(
       name,
       description,
       unit,
-      enabled,
       meter,
     );
   }

--- a/lib/src/api/metrics/histogram.dart
+++ b/lib/src/api/metrics/histogram.dart
@@ -21,9 +21,6 @@ class APIHistogram<T extends num> {
   /// The optional unit of measure for this histogram instrument.
   final String? _unit;
 
-  /// Whether this histogram is enabled for recording measurements.
-  final bool _enabled;
-
   /// The meter that created this histogram instrument.
   final APIMeter _meter;
 
@@ -37,11 +34,9 @@ class APIHistogram<T extends num> {
   /// [_name] The name of the histogram instrument.
   /// [_description] Optional description of the histogram instrument.
   /// [_unit] Optional unit of measurement for the histogram.
-  /// [_enabled] Whether this histogram is enabled for recording measurements.
   /// [_meter] The meter that created this histogram instrument.
   /// [boundaries] Optional explicit bucket boundaries for the histogram.
-  APIHistogram(
-      this._name, this._description, this._unit, this._enabled, this._meter,
+  APIHistogram(this._name, this._description, this._unit, this._meter,
       {List<double>? boundaries})
       : _boundaries = boundaries != null ? List.unmodifiable(boundaries) : null;
 
@@ -54,8 +49,13 @@ class APIHistogram<T extends num> {
   /// Returns the unit of this Histogram.
   String? get unit => _unit;
 
-  /// Returns whether this histogram is enabled.
-  bool get enabled => _enabled;
+  /// Returns whether the instrument is enabled and will record measurements.
+  ///
+  /// The returned value can change over time; instrumentation authors need
+  /// to call this before each measurement to ensure they have the most
+  /// up-to-date response. The base API implementation always returns false;
+  /// SDK subclasses override this to compute the real, current value.
+  bool isEnabled() => false;
 
   /// Returns the meter that created this histogram.
   APIMeter get meter => _meter;

--- a/lib/src/api/metrics/histogram_create.dart
+++ b/lib/src/api/metrics/histogram_create.dart
@@ -14,7 +14,6 @@ class HistogramCreate {
     required String name,
     String? unit,
     String? description,
-    required bool enabled,
     required APIMeter meter,
     List<double>? boundaries,
   }) {
@@ -22,7 +21,6 @@ class HistogramCreate {
       name,
       description,
       unit,
-      enabled,
       meter,
       boundaries: boundaries,
     );

--- a/lib/src/api/metrics/instrument.dart
+++ b/lib/src/api/metrics/instrument.dart
@@ -12,7 +12,6 @@ class APIInstrument {
   final String _name;
   final String? _unit;
   final String? _description;
-  final bool _enabled;
   final APIMeter _meter;
 
   /// Creates a new instrument with the specified parameters.
@@ -20,18 +19,15 @@ class APIInstrument {
   /// [name] The name of the instrument (required).
   /// [unit] The optional unit of measurement.
   /// [description] An optional human-readable description.
-  /// [enabled] Whether the instrument is enabled and will record measurements.
   /// [meter] The meter that created this instrument.
   APIInstrument({
     required String name,
     String? unit,
     String? description,
-    required bool enabled,
     required APIMeter meter,
   })  : _name = name,
         _unit = unit,
         _description = description,
-        _enabled = enabled,
         _meter = meter;
 
   /// The name of the instrument, e.g., 'http.server.request_duration'.
@@ -45,7 +41,12 @@ class APIInstrument {
   String? get description => _description;
 
   /// Returns whether the instrument is enabled and will record measurements.
-  bool get enabled => _enabled;
+  ///
+  /// The returned value can change over time; instrumentation authors need
+  /// to call this before each measurement to ensure they have the most
+  /// up-to-date response. The base API implementation always returns false;
+  /// SDK subclasses override this to compute the real, current value.
+  bool isEnabled() => false;
 
   /// The Meter that created this instrument.
   APIMeter get meter => _meter;

--- a/lib/src/api/metrics/meter.dart
+++ b/lib/src/api/metrics/meter.dart
@@ -44,8 +44,13 @@ class APIMeter {
     this.attributes,
   });
 
-  /// Returns true if the meter is enabled and will create instruments.
-  bool get enabled => false;
+  /// Returns whether the meter is enabled and will create instruments.
+  ///
+  /// The returned value can change over time; instrumentation authors need
+  /// to call this before creating instruments to ensure they have the most
+  /// up-to-date response. The base API implementation always returns false;
+  /// SDK subclasses override this to compute the real, current value.
+  bool isEnabled() => false;
 
   /// Creates a [Counter] with the given name.
   ///
@@ -67,7 +72,6 @@ class APIMeter {
       name: name,
       unit: unit,
       description: description,
-      enabled: enabled,
       meter: this,
     );
   }
@@ -92,7 +96,6 @@ class APIMeter {
       name: name,
       unit: unit,
       description: description,
-      enabled: enabled,
       meter: this,
     );
   }
@@ -120,7 +123,6 @@ class APIMeter {
       name: name,
       unit: unit,
       description: description,
-      enabled: enabled,
       meter: this,
       boundaries: boundaries,
     );
@@ -147,7 +149,6 @@ class APIMeter {
       name: name,
       unit: unit,
       description: description,
-      enabled: enabled,
       meter: this,
     );
   }
@@ -175,7 +176,6 @@ class APIMeter {
       name: name,
       unit: unit,
       description: description,
-      enabled: enabled,
       meter: this,
       callback: callback,
     );
@@ -204,7 +204,6 @@ class APIMeter {
       name: name,
       unit: unit,
       description: description,
-      enabled: enabled,
       meter: this,
       callback: callback,
     );
@@ -233,7 +232,6 @@ class APIMeter {
       name: name,
       unit: unit,
       description: description,
-      enabled: enabled,
       meter: this,
       callback: callback,
     );

--- a/lib/src/api/metrics/observable_counter.dart
+++ b/lib/src/api/metrics/observable_counter.dart
@@ -18,13 +18,12 @@ class APIObservableCounter<T extends num> {
   final String _name;
   final String? _description;
   final String? _unit;
-  final bool _enabled;
   final APIMeter _meter;
   final List<ObservableCallback<T>> _callbacks = [];
 
   /// Creates a new observable counter instrument
-  APIObservableCounter(this._name, this._description, this._unit, this._enabled,
-      this._meter, ObservableCallback<T>? callback) {
+  APIObservableCounter(this._name, this._description, this._unit, this._meter,
+      ObservableCallback<T>? callback) {
     if (callback != null) {
       addCallback(callback);
     }
@@ -39,8 +38,13 @@ class APIObservableCounter<T extends num> {
   /// Returns the unit of this observable counter.
   String? get unit => _unit;
 
-  /// Returns whether this observable counter is enabled.
-  bool get enabled => _enabled;
+  /// Returns whether the instrument is enabled and will record measurements.
+  ///
+  /// The returned value can change over time; instrumentation authors need
+  /// to call this before each measurement to ensure they have the most
+  /// up-to-date response. The base API implementation always returns false;
+  /// SDK subclasses override this to compute the real, current value.
+  bool isEnabled() => false;
 
   /// Returns the meter that created this observable counter.
   APIMeter get meter => _meter;

--- a/lib/src/api/metrics/observable_counter_create.dart
+++ b/lib/src/api/metrics/observable_counter_create.dart
@@ -14,7 +14,6 @@ class ObservableCounterCreate {
     required String name,
     String? unit,
     String? description,
-    required bool enabled,
     required APIMeter meter,
     ObservableCallback<T>? callback,
   }) {
@@ -22,7 +21,6 @@ class ObservableCounterCreate {
       name,
       description,
       unit,
-      enabled,
       meter,
       callback,
     );

--- a/lib/src/api/metrics/observable_gauge.dart
+++ b/lib/src/api/metrics/observable_gauge.dart
@@ -18,13 +18,11 @@ class APIObservableGauge<T extends num> {
   final String _name;
   final String? _description;
   final String? _unit;
-  final bool _enabled;
   final APIMeter _meter;
   final List<ObservableCallback<T>> _callbacks = [];
 
   /// Creates a new observable gauge instrument
-  APIObservableGauge(
-      this._name, this._description, this._unit, this._enabled, this._meter,
+  APIObservableGauge(this._name, this._description, this._unit, this._meter,
       [ObservableCallback<T>? callback]) {
     if (callback != null) {
       addCallback(callback);
@@ -40,8 +38,13 @@ class APIObservableGauge<T extends num> {
   /// Returns the unit of this observable gauge.
   String? get unit => _unit;
 
-  /// Returns whether this observable gauge is enabled.
-  bool get enabled => _enabled;
+  /// Returns whether the instrument is enabled and will record measurements.
+  ///
+  /// The returned value can change over time; instrumentation authors need
+  /// to call this before each measurement to ensure they have the most
+  /// up-to-date response. The base API implementation always returns false;
+  /// SDK subclasses override this to compute the real, current value.
+  bool isEnabled() => false;
 
   /// Returns the meter that created this observable gauge.
   APIMeter get meter => _meter;

--- a/lib/src/api/metrics/observable_gauge_create.dart
+++ b/lib/src/api/metrics/observable_gauge_create.dart
@@ -14,7 +14,6 @@ class ObservableGaugeCreate {
     required String name,
     String? unit,
     String? description,
-    required bool enabled,
     required APIMeter meter,
     ObservableCallback<T>? callback,
   }) {
@@ -22,7 +21,6 @@ class ObservableGaugeCreate {
       name,
       description,
       unit,
-      enabled,
       meter,
       callback,
     );

--- a/lib/src/api/metrics/observable_up_down_counter.dart
+++ b/lib/src/api/metrics/observable_up_down_counter.dart
@@ -17,13 +17,12 @@ class APIObservableUpDownCounter<T extends num> {
   final String _name;
   final String? _description;
   final String? _unit;
-  final bool _enabled;
   final APIMeter _meter;
   final List<ObservableCallback<T>> _callbacks = [];
 
   /// Creates a new observable up-down counter instrument
   APIObservableUpDownCounter(
-      this._name, this._description, this._unit, this._enabled, this._meter,
+      this._name, this._description, this._unit, this._meter,
       [ObservableCallback<T>? callback]) {
     if (callback != null) {
       addCallback(callback);
@@ -39,8 +38,13 @@ class APIObservableUpDownCounter<T extends num> {
   /// Returns the unit of this observable up-down counter.
   String? get unit => _unit;
 
-  /// Returns whether this observable up-down counter is enabled.
-  bool get enabled => _enabled;
+  /// Returns whether the instrument is enabled and will record measurements.
+  ///
+  /// The returned value can change over time; instrumentation authors need
+  /// to call this before each measurement to ensure they have the most
+  /// up-to-date response. The base API implementation always returns false;
+  /// SDK subclasses override this to compute the real, current value.
+  bool isEnabled() => false;
 
   /// Returns the meter that created this observable up-down counter.
   APIMeter get meter => _meter;

--- a/lib/src/api/metrics/observable_up_down_counter_create.dart
+++ b/lib/src/api/metrics/observable_up_down_counter_create.dart
@@ -14,7 +14,6 @@ class ObservableUpDownCounterCreate<T extends num> {
     required String name,
     String? unit,
     String? description,
-    required bool enabled,
     required APIMeter meter,
     ObservableCallback<T>? callback,
   }) {
@@ -22,7 +21,6 @@ class ObservableUpDownCounterCreate<T extends num> {
       name,
       description,
       unit,
-      enabled,
       meter,
       callback,
     );

--- a/lib/src/api/metrics/up_down_counter.dart
+++ b/lib/src/api/metrics/up_down_counter.dart
@@ -21,9 +21,6 @@ class APIUpDownCounter<T extends num> {
   /// The optional unit of measure for this up-down counter instrument.
   final String? _unit;
 
-  /// Whether this up-down counter is enabled for recording measurements.
-  final bool _enabled;
-
   /// The meter that created this up-down counter instrument.
   final APIMeter _meter;
 
@@ -34,13 +31,11 @@ class APIUpDownCounter<T extends num> {
   /// [_name] The name of the up-down counter instrument.
   /// [_description] Optional description of the up-down counter instrument.
   /// [_unit] Optional unit of measurement for the up-down counter.
-  /// [_enabled] Whether this up-down counter is enabled for recording measurements.
   /// [_meter] The meter that created this up-down counter instrument.
   APIUpDownCounter(
     this._name,
     this._description,
     this._unit,
-    this._enabled,
     this._meter,
   );
 
@@ -53,8 +48,13 @@ class APIUpDownCounter<T extends num> {
   /// Returns the unit of this UpDownCounter.
   String? get unit => _unit;
 
-  /// Returns whether this counter is enabled.
-  bool get enabled => _enabled;
+  /// Returns whether the instrument is enabled and will record measurements.
+  ///
+  /// The returned value can change over time; instrumentation authors need
+  /// to call this before each measurement to ensure they have the most
+  /// up-to-date response. The base API implementation always returns false;
+  /// SDK subclasses override this to compute the real, current value.
+  bool isEnabled() => false;
 
   /// Returns the meter that created this counter.
   APIMeter get meter => _meter;

--- a/lib/src/api/metrics/up_down_counter_create.dart
+++ b/lib/src/api/metrics/up_down_counter_create.dart
@@ -14,14 +14,12 @@ class UpDownCounterCreate {
     required String name,
     String? unit,
     String? description,
-    required bool enabled,
     required APIMeter meter,
   }) {
     return APIUpDownCounter<T>(
       name,
       description,
       unit,
-      enabled,
       meter,
     );
   }

--- a/lib/src/api/trace/tracer.dart
+++ b/lib/src/api/trace/tracer.dart
@@ -249,8 +249,8 @@ class APITracer {
       links: links,
       spanEvents: spanEvents,
       startTime: startTime,
-      isRecording:
-          isRecording ?? true && isEnabled(kind: kind, context: contextOfSpan),
+      isRecording: (isRecording ?? true) &&
+          isEnabled(kind: kind, context: contextOfSpan),
       timeProvider: timeProvider,
     );
     return apiSpan;

--- a/lib/src/api/trace/tracer.dart
+++ b/lib/src/api/trace/tracer.dart
@@ -57,9 +57,17 @@ class APITracer {
     TimeProvider? timeProvider,
   }) : timeProvider = timeProvider ?? defaultTimeProvider;
 
-  /// Returns true if the tracer is enabled and will create sampling spans.
+  /// Returns whether this tracer is enabled for the provided arguments.
   /// This should be checked before performing expensive operations to create spans.
-  bool get enabled => false;
+  ///
+  /// The returned value can change over time; instrumentation authors need
+  /// to call this each time they create a new span to ensure they have the
+  /// most up-to-date response.
+  ///
+  /// No parameters are currently required by the spec, but this is a method
+  /// (not a getter) so parameters such as [kind] and [context] can be added
+  /// later without a breaking change.
+  bool isEnabled({SpanKind? kind, Context? context}) => false;
 
   /// Gets the currently active span from the current context
   APISpan? get currentSpan => Context.current.span;
@@ -241,7 +249,8 @@ class APITracer {
       links: links,
       spanEvents: spanEvents,
       startTime: startTime,
-      isRecording: isRecording ?? true && enabled,
+      isRecording:
+          isRecording ?? true && isEnabled(kind: kind, context: contextOfSpan),
       timeProvider: timeProvider,
     );
     return apiSpan;

--- a/test/unit/api/logs/logger_test.dart
+++ b/test/unit/api/logs/logger_test.dart
@@ -79,7 +79,7 @@ void main() {
       final logger = provider.getLogger('test-logger');
 
       // API logger is always disabled (no-op)
-      expect(logger.enabled, isFalse);
+      expect(logger.isEnabled(), isFalse);
     });
 
     test('emit does not throw with minimal parameters', () {

--- a/test/unit/api/metrics/counter_test.dart
+++ b/test/unit/api/metrics/counter_test.dart
@@ -31,7 +31,7 @@ void main() {
       expect(counter.unit, equals('ms'));
       expect(counter.description, equals('A test counter'));
       expect(counter.meter, equals(meter));
-      expect(counter.enabled,
+      expect(counter.isEnabled(),
           isFalse); // API implementation is disabled by default
       expect(counter.isCounter, isTrue);
       expect(counter.isUpDownCounter, isFalse);

--- a/test/unit/api/metrics/gauge_test.dart
+++ b/test/unit/api/metrics/gauge_test.dart
@@ -31,8 +31,8 @@ void main() {
       expect(gauge.unit, equals('celsius'));
       expect(gauge.description, equals('A test gauge'));
       expect(gauge.meter, equals(meter));
-      expect(
-          gauge.enabled, isFalse); // API implementation is disabled by default
+      expect(gauge.isEnabled(),
+          isFalse); // API implementation is disabled by default
       expect(gauge.isCounter, isFalse);
       expect(gauge.isUpDownCounter, isFalse);
       expect(gauge.isGauge, isTrue);

--- a/test/unit/api/metrics/histogram_test.dart
+++ b/test/unit/api/metrics/histogram_test.dart
@@ -44,7 +44,7 @@ void main() {
       expect(histogram.unit, equals('ms'));
       expect(histogram.description, equals('A test histogram'));
       expect(histogram.meter, equals(meter));
-      expect(histogram.enabled,
+      expect(histogram.isEnabled(),
           isFalse); // API implementation is disabled by default
       expect(histogram.isCounter, isFalse);
       expect(histogram.isUpDownCounter, isFalse);

--- a/test/unit/api/metrics/instrument_test.dart
+++ b/test/unit/api/metrics/instrument_test.dart
@@ -26,14 +26,12 @@ void main() {
       const name = 'test-instrument';
       const unit = 'ms';
       const description = 'A test instrument';
-      const enabled = true;
 
       // Act
       final instrument = TestAPIInstrument(
         name: name,
         unit: unit,
         description: description,
-        enabled: enabled,
         meter: meter,
       );
 
@@ -41,21 +39,19 @@ void main() {
       expect(instrument.name, equals(name));
       expect(instrument.unit, equals(unit));
       expect(instrument.description, equals(description));
-      expect(instrument.enabled, equals(enabled));
+      expect(instrument.isEnabled(), isFalse); // Base API default
       expect(instrument.meter, equals(meter));
     });
 
     test('instrument works with null unit and description', () {
       // Arrange
       const name = 'test-instrument';
-      const enabled = false;
 
       // Act
       final instrument = TestAPIInstrument(
         name: name,
         unit: null,
         description: null,
-        enabled: enabled,
         meter: meter,
       );
 
@@ -63,8 +59,19 @@ void main() {
       expect(instrument.name, equals(name));
       expect(instrument.unit, isNull);
       expect(instrument.description, isNull);
-      expect(instrument.enabled, equals(enabled));
+      expect(instrument.isEnabled(), isFalse); // Base API default
       expect(instrument.meter, equals(meter));
+    });
+
+    test('subclass can override isEnabled', () {
+      // Act
+      final instrument = OverriddenAPIInstrument(
+        name: 'test-instrument',
+        meter: meter,
+      );
+
+      // Assert
+      expect(instrument.isEnabled(), isTrue); // Confirm override path works
     });
 
     test('specific instrument types extend APIInstrument', () {
@@ -97,7 +104,17 @@ class TestAPIInstrument extends APIInstrument {
     required super.name,
     super.unit,
     super.description,
-    required super.enabled,
     required super.meter,
   });
+}
+
+/// Test implementation of APIInstrument overriding isEnabled
+class OverriddenAPIInstrument extends APIInstrument {
+  OverriddenAPIInstrument({
+    required super.name,
+    required super.meter,
+  });
+
+  @override
+  bool isEnabled() => true;
 }

--- a/test/unit/api/metrics/meter_test.dart
+++ b/test/unit/api/metrics/meter_test.dart
@@ -33,7 +33,7 @@ void main() {
       // Assert
       expect(counter, isNotNull);
       expect(counter.name, equals('test-counter'));
-      expect(counter.enabled,
+      expect(counter.isEnabled(),
           isFalse); // API implementation is disabled by default
       expect(counter.isCounter, isTrue);
       expect(counter.isUpDownCounter, isFalse);
@@ -57,7 +57,7 @@ void main() {
       // Assert
       expect(upDownCounter, isNotNull);
       expect(upDownCounter.name, equals('test-up-down-counter'));
-      expect(upDownCounter.enabled,
+      expect(upDownCounter.isEnabled(),
           isFalse); // API implementation is disabled by default
       expect(upDownCounter.isCounter, isFalse);
       expect(upDownCounter.isUpDownCounter, isTrue);
@@ -80,7 +80,7 @@ void main() {
       // Assert
       expect(histogram, isNotNull);
       expect(histogram.name, equals('test-histogram'));
-      expect(histogram.enabled,
+      expect(histogram.isEnabled(),
           isFalse); // API implementation is disabled by default
       expect(histogram.isCounter, isFalse);
       expect(histogram.isUpDownCounter, isFalse);
@@ -103,8 +103,8 @@ void main() {
       // Assert
       expect(gauge, isNotNull);
       expect(gauge.name, equals('test-gauge'));
-      expect(
-          gauge.enabled, isFalse); // API implementation is disabled by default
+      expect(gauge.isEnabled(),
+          isFalse); // API implementation is disabled by default
       expect(gauge.isCounter, isFalse);
       expect(gauge.isUpDownCounter, isFalse);
       expect(gauge.isGauge, isTrue);
@@ -127,7 +127,7 @@ void main() {
       // Assert
       expect(observableCounter, isNotNull);
       expect(observableCounter.name, equals('test-observable-counter'));
-      expect(observableCounter.enabled,
+      expect(observableCounter.isEnabled(),
           isFalse); // API implementation is disabled by default
     });
 
@@ -149,7 +149,7 @@ void main() {
       expect(observableUpDownCounter, isNotNull);
       expect(observableUpDownCounter.name,
           equals('test-observable-up-down-counter'));
-      expect(observableUpDownCounter.enabled,
+      expect(observableUpDownCounter.isEnabled(),
           isFalse); // API implementation is disabled by default
     });
 
@@ -169,7 +169,7 @@ void main() {
       // Assert
       expect(observableGauge, isNotNull);
       expect(observableGauge.name, equals('test-observable-gauge'));
-      expect(observableGauge.enabled,
+      expect(observableGauge.isEnabled(),
           isFalse); // API implementation is disabled by default
     });
 

--- a/test/unit/api/metrics/meter_test.dart
+++ b/test/unit/api/metrics/meter_test.dart
@@ -23,6 +23,7 @@ void main() {
       // Assert
       expect(meter.name, equals('test-meter'));
       expect(meter.version, isNotNull);
+      expect(meter.isEnabled(), isFalse);
       expect(meter.schemaUrl, isNotNull);
     });
 

--- a/test/unit/api/metrics/observable_counter_test.dart
+++ b/test/unit/api/metrics/observable_counter_test.dart
@@ -37,7 +37,7 @@ void main() {
       expect(
           observableCounter.description, equals('A test observable counter'));
       expect(observableCounter.meter, equals(meter));
-      expect(observableCounter.enabled,
+      expect(observableCounter.isEnabled(),
           isFalse); // API implementation is disabled by default
     });
 

--- a/test/unit/api/metrics/observable_gauge_test.dart
+++ b/test/unit/api/metrics/observable_gauge_test.dart
@@ -37,7 +37,7 @@ void main() {
       expect(observableGauge.unit, equals('celsius'));
       expect(observableGauge.description, equals('A test observable gauge'));
       expect(observableGauge.meter, equals(meter));
-      expect(observableGauge.enabled,
+      expect(observableGauge.isEnabled(),
           isFalse); // API implementation is disabled by default
     });
 

--- a/test/unit/api/metrics/observable_up_down_counter_test.dart
+++ b/test/unit/api/metrics/observable_up_down_counter_test.dart
@@ -39,7 +39,7 @@ void main() {
       expect(observableUpDownCounter.description,
           equals('A test observable up-down counter'));
       expect(observableUpDownCounter.meter, equals(meter));
-      expect(observableUpDownCounter.enabled,
+      expect(observableUpDownCounter.isEnabled(),
           isFalse); // API implementation is disabled by default
     });
 

--- a/test/unit/api/metrics/up_down_counter_test.dart
+++ b/test/unit/api/metrics/up_down_counter_test.dart
@@ -31,7 +31,7 @@ void main() {
       expect(upDownCounter.unit, equals('bytes'));
       expect(upDownCounter.description, equals('A test up-down counter'));
       expect(upDownCounter.meter, equals(meter));
-      expect(upDownCounter.enabled,
+      expect(upDownCounter.isEnabled(),
           isFalse); // API implementation is disabled by default
       expect(upDownCounter.isCounter, isFalse);
       expect(upDownCounter.isUpDownCounter, isTrue);

--- a/test/unit/api/trace/tracer_test.dart
+++ b/test/unit/api/trace/tracer_test.dart
@@ -35,6 +35,7 @@ void main() {
       expect(tracer.version, equals('1.11.0.0'));
       expect(
           tracer.schemaUrl, equals('https://opentelemetry.io/schemas/1.11.0'));
+      expect(tracer.isEnabled(), isFalse);
     });
 
     test('creates span with name only', () {


### PR DESCRIPTION
## Description
Replaces the `enabled` getter with an `isEnabled()` method on `APITracer`, `APILogger`, `APIInstrument`, and all seven instrument subclasses (Counter, UpDownCounter, Histogram, Gauge, ObservableCounter, ObservableUpDownCounter, ObservableGauge). A Dart getter cannot take parameters, so the previous shape blocked the spec-mandated ability to add parameters (e.g. SpanKind/Context for Trace; Context/SeverityNumber/EventName for Logs) without another breaking change later.

The `enabled` constructor parameter is also removed from all instrument constructors and `*Create.create()` factories — per #99's guidance, the value should be computed by an SDK subclass on each call rather than captured once at construction time in a `final` field.

**BREAKING CHANGE**: `.enabled` → `.isEnabled()` everywhere above. Any downstream code reading `.enabled` or passing `enabled:` to these constructors will need to update.

**Explicitly out of scope**: `APITracerProvider.enabled`, `APIMeterProvider.enabled`, `APILoggerProvider.enabled` (getter *and* setter) are untouched. These are provider lifecycle/shutdown state, not the spec's per-call "Enabled" check, and are a different concept.

## Link to tracking issue
Fixes #85
Fixes #90
Fixes #99

## Testing
- `dart analyze`: 0 issues
- `dart test`: full suite passes
- `instrument_test.dart` rewritten (not just renamed) to test the new semantics: base API `isEnabled()` returns `false` by default, and a subclass overriding `isEnabled()` is respected — the actual point of the fix, since real enablement logic now lives entirely in SDK subclasses.
- All other affected test files (`logger_test.dart`, `counter_test.dart`, `gauge_test.dart`, `histogram_test.dart`, `up_down_counter_test.dart`, `observable_counter_test.dart`, `observable_gauge_test.dart`,  `observable_up_down_counter_test.dart`, `meter_test.dart`) updated to call `.isEnabled()` instead of reading `.enabled`.
- Verified via `grep -rn "\.enabled\b|get enabled\b"` across `lib/` and `test/` that no reference to the old shape remains outside the intentionally-untouched `*Provider` classes.

## Documentation
- Doc comments on each `isEnabled()` note that the returned value can change over time and should be called before each span/measurement/log record, per the spec.
- `CHANGELOG.md` updated under `[1.0.0-rc.3-wip]` with a `### Changed` / **BREAKING** entry.

## Spec Compliance
- Trace API — Enabled (MUST/SHOULD, v1.60.0): https://opentelemetry.io/docs/specs/otel/trace/api/#enabled
- Logs API — Enabled (SHOULD, v1.60.0): https://opentelemetry.io/docs/specs/otel/logs/api/#enabled
- Metrics API — Enabled (MUST/SHOULD, v1.60.0): https://opentelemetry.io/docs/specs/otel/metrics/api/#enabled
