### PR TITLE
fix(api): typed Attributes getters return null on type mismatch (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#117](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/117)).
 - Empty string and empty array attribute values no longer throw `ArgumentError`
   ([#103](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/103)).
+- Typed `Attributes` getters return null on a type mismatch instead of throwing
+  `StateError`, and report it through the error handler
+  ([#106](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/106)).
 
 ## [1.0.0-rc.3] - 2026-08-27
 

--- a/lib/src/api/common/attributes.dart
+++ b/lib/src/api/common/attributes.dart
@@ -141,17 +141,24 @@ class Attributes {
   /// Returns the number of attributes in this collection.
   int get length => _entries.length;
 
-  /// Returns the value associated with the given [key], or null if not present.
+  /// Returns the value associated with the given [key], or null if the key
+  /// is not present or the stored value is not of type [T].
+  ///
+  /// error-handling.md: API methods MUST NOT throw unhandled exceptions
+  /// when used incorrectly by end users. A type mismatch is reported
+  /// through [OTelErrorHandling] and null is returned.
   T? _getTyped<T>(String key) {
     final attribute = _entries[key];
     if (attribute == null) return null;
 
-    // Ensure the value matches the expected type `T`
-    if (attribute.value is T) {
-      return attribute.value as T;
-    } else {
-      throw StateError('Value for key "$key" is not of type $T');
+    final value = attribute.value;
+    if (value is T) {
+      return value as T;
     }
+    OTelErrorHandling.report(
+        StateError('Attribute value for key "$key" is a ${value.runtimeType}, '
+            'not a $T; returning null.'));
+    return null;
   }
 
   /// Creates a new Attributes instance with a String attribute added or updated.

--- a/test/unit/api/common/attributes_test.dart
+++ b/test/unit/api/common/attributes_test.dart
@@ -348,15 +348,24 @@ void main() {
       expect(attrs.isEmpty, isFalse);
     });
 
-    test('_getTyped throws StateError for wrong type', () {
+    test('typed getters return null for wrong type and report the mismatch',
+        () {
+      // error-handling.md: API methods MUST NOT throw unhandled
+      // exceptions when used incorrectly by end users.
+      final reported = <Object>[];
+      OTelErrorHandling.handler = (error, stackTrace) => reported.add(error);
+      addTearDown(OTelErrorHandling.resetToDefault);
+
       final attrs = OTelAPI.attributes([
         OTelAPI.attributeString('key', 'value'),
       ]);
 
-      expect(
-        () => attrs.getInt('key'),
-        throwsA(isA<StateError>()),
-      );
+      expect(attrs.getInt('key'), isNull);
+      expect(reported, hasLength(1));
+      expect(reported.single, isA<StateError>());
+      // The stored value is still readable with the right type.
+      expect(attrs.getString('key'), equals('value'));
+      expect(reported, hasLength(1));
     });
 
     test('get methods return null for missing key', () {

--- a/test/unit/api/factory/otel_api_factory_test.dart
+++ b/test/unit/api/factory/otel_api_factory_test.dart
@@ -147,8 +147,9 @@ void main() {
 
       expect(attributes.length, equals(2));
       expect(attributes.getString('string-key'), equals('string-value'));
-      // Test that trying to get an int value as a string throws an exception
-      expect(() => attributes.getString('int-key'), throwsA(isA<StateError>()));
+      // Getting an int value as a string returns null (never throws,
+      // per error-handling.md)
+      expect(attributes.getString('int-key'), isNull);
       // Test getting the value with correct type
       expect(attributes.getInt('int-key'), equals(42));
     });
@@ -171,8 +172,9 @@ void main() {
 
       expect(attributes.length, equals(9));
       expect(attributes.getString('string-key'), equals('string-value'));
-      // Test that trying to get an int value as a string throws an exception
-      expect(() => attributes.getString('int-key'), throwsA(isA<StateError>()));
+      // Getting an int value as a string returns null (never throws,
+      // per error-handling.md)
+      expect(attributes.getString('int-key'), isNull);
       // Test getting the value with correct type
       expect(attributes.getInt('int-key'), equals(42));
       expect(attributes.getDouble('double-key'), equals(3.14));
@@ -198,8 +200,9 @@ void main() {
 
       expect(attributes.length, equals(2));
       expect(attributes.getString('string-key'), equals('string-value'));
-      // Test that trying to get an int value as a string throws an exception
-      expect(() => attributes.getString('int-key'), throwsA(isA<StateError>()));
+      // Getting an int value as a string returns null (never throws,
+      // per error-handling.md)
+      expect(attributes.getString('int-key'), isNull);
       // Test getting the value with correct type
       expect(attributes.getInt('int-key'), equals(42));
     });


### PR DESCRIPTION
> **Stacked on #103.** This branch is based on `abidiahmedcom:fix/empty-attribute-values`, so the diff against `main` currently includes #103's commits as well. **The change under review here is the single commit `8141ac1`**, which touches `attributes.dart` (`_getTyped`), its two test files, and one CHANGELOG entry. Once #103 merges, this diff collapses to just that. Review [8141ac1](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/106/commits/8141ac1) directly rather than the Files tab.

Fixes #81. Follow-up to #103, and **based on that branch**, so it should merge after #103.

## What

`_getTyped` returns null on a type mismatch and reports it through `OTelErrorHandling`, instead of throwing `StateError`. Affects `getString`, `getBool`, `getInt`, `getDouble` and the four list getters.

## Why

The getters' doc comments already promise this. `getStringList`:

> Returns null if the key doesn't exist or if the value is not a String List.

The implementation threw instead, so the methods contradicted their own documented contract. `error-handling.md` also states that API methods must not throw unhandled exceptions when used incorrectly by end users, and a wrong-type read is exactly that.

Reporting through the error handler rather than returning null silently means a strict-mode handler still surfaces the mismatch. The value is not swallowed, it just stops being an exception on the caller's happy path.

## Relationship to #103

**#103 does not create the throwing path.** `_getTyped` throws on any type mismatch today, and #103 does not touch that method. What #103 changes is *reachability*: while empty lists were silently dropped the key was absent, so the getter returned null and an empty typed list could never reach the mismatch branch. Storing them, which #80 requires, makes an existing bug reachable on one more path.

Found by @robert-northmind while reviewing #103.

## Verification

- `dart analyze --fatal-infos`: no issues
- `dart test`: 1177/1177 pass
- Mutation verified: restoring the `StateError` throw fails four tests, in `attributes_test.dart` and `otel_api_factory_test.dart`. The tests hold the fix rather than merely accompanying it.
