### PR TITLE
fix(api): getTracer must not invent a scope version or schema URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-rc.3-wip]
 
+### Fixed (spec compliance)
+- **`TracerProvider.getTracer` no longer invents a scope version or schema
+  URL** (api#64). A caller who omits `version`/`schemaUrl` now gets a tracer
+  — and spans from it — with a `null` scope version and schema URL, instead
+  of this package's own version constant and a schema URL the instrumented
+  library never declared. Tracer identity (the cache key) no longer varies
+  on these invented values either, so `getTracer('x')` and
+  `getTracer('x', attributes: a)` now differ only in the parameter the
+  caller actually set.
+
 ## [1.0.0-rc.2] - 2026-08-23
 
 ### Added

--- a/lib/src/api/common/instrumentation_scope_create.dart
+++ b/lib/src/api/common/instrumentation_scope_create.dart
@@ -17,7 +17,7 @@ class InstrumentationScopeCreate {
   /// @return A new InstrumentationScope instance
   static InstrumentationScope create({
     required String name,
-    String version = '1.0.0',
+    String? version,
     String? schemaUrl,
     Attributes? attributes,
   }) {

--- a/lib/src/api/trace/tracer.dart
+++ b/lib/src/api/trace/tracer.dart
@@ -231,7 +231,7 @@ class APITracer {
       name: name,
       instrumentationScope: InstrumentationScopeCreate.create(
           name: this.name,
-          version: version ?? '1.0.0',
+          version: version,
           schemaUrl: schemaUrl,
           attributes: attributes),
       spanContext: effectiveSpanContext,

--- a/lib/src/api/trace/tracer_provider.dart
+++ b/lib/src/api/trace/tracer_provider.dart
@@ -95,27 +95,19 @@ class APITracerProvider {
           'Invalid tracer name provided; using empty string as fallback.'));
     }
 
-    // Apply default values if none are provided
-    var effectiveVersion = version;
-    var effectiveSchemaUrl = schemaUrl;
-
-    // Only apply defaults if all optional parameters are missing
-    if (version == null && schemaUrl == null && attributes == null) {
-      effectiveVersion = OTelAPI.defaultServiceVersion;
-      effectiveSchemaUrl = OTelAPI.defaultSchemaUrl;
-    }
-
-    // Create a cache key based on the provided parameters.
-    final key = SignalInstanceKey(validatedName, effectiveVersion,
-        effectiveSchemaUrl, attributes, Signal.traces);
+    // Create a cache key based on the provided parameters. A caller who
+    // omits version/schemaUrl gets a tracer with a null scope version and
+    // schema URL — the API must not invent values the caller never stated.
+    final key = SignalInstanceKey(
+        validatedName, version, schemaUrl, attributes, Signal.traces);
 
     if (_tracerCache.containsKey(key)) {
       return _tracerCache[key]!;
     } else {
       final tracer = TracerCreate.create(
         name: validatedName,
-        version: effectiveVersion,
-        schemaUrl: effectiveSchemaUrl,
+        version: version,
+        schemaUrl: schemaUrl,
         attributes: attributes,
         timeProvider: timeProvider,
       );

--- a/test/unit/api/trace/tracer_provider_defaults_test.dart
+++ b/test/unit/api/trace/tracer_provider_defaults_test.dart
@@ -19,16 +19,18 @@ void main() {
       tracerProvider = OTelAPI.tracerProvider();
     });
 
-    test('applies all defaults when no optional parameters are provided', () {
+    test(
+        'does not invent a scope version or schema URL when no optional '
+        'parameters are provided', () {
       // Act
       final tracer = tracerProvider.getTracer('test-tracer');
 
       // Assert
       expect(tracer.name, equals('test-tracer'));
-      expect(tracer.version,
-          equals('1.11.0.0')); // Default version should be applied
-      expect(tracer.schemaUrl,
-          equals(OTelAPI.defaultSchemaUrl)); // Default schema should be applied
+      // The caller stated no version or schema URL, so the API must not
+      // report the package's own version constant or a fabricated schema.
+      expect(tracer.version, isNull);
+      expect(tracer.schemaUrl, isNull);
       expect(tracer.attributes, isNull);
     });
 
@@ -86,6 +88,30 @@ void main() {
       expect(tracer.schemaUrl, isNull); // No default schema
       expect(tracer.attributes, isNotNull);
       expect(tracer.attributes!.getString('key'), equals('value'));
+    });
+
+    test(
+        'a tracer requested with only attributes is distinct only in '
+        'attributes, not in an invented version/schemaUrl', () {
+      final bare = tracerProvider.getTracer('same-name');
+      final withAttrs = tracerProvider.getTracer('same-name',
+          attributes: {'key': 'value'}.toAttributes());
+
+      expect(bare.version, isNull);
+      expect(withAttrs.version, isNull);
+      expect(bare.schemaUrl, isNull);
+      expect(withAttrs.schemaUrl, isNull);
+      expect(identical(bare, withAttrs), isFalse);
+    });
+
+    test(
+        'a span from a tracer with no version does not report an invented '
+        'instrumentation scope version', () {
+      final tracer = tracerProvider.getTracer('test-tracer');
+      final span = tracer.startSpan('test-span');
+
+      expect(span.instrumentationScope.version, isNull);
+      expect(span.instrumentationScope.schemaUrl, isNull);
     });
   });
 }

--- a/test/unit/api/trace/tracer_test.dart
+++ b/test/unit/api/trace/tracer_test.dart
@@ -28,13 +28,12 @@ void main() {
       OTelFactory.otelFactory = originalFactory;
     });
 
-    test('creates with name, version, and schemaUrl', () {
+    test('does not invent a version or schemaUrl when none are given', () {
       final tracer = OTelAPI.tracer('test-tracer');
 
       expect(tracer.name, equals('test-tracer'));
-      expect(tracer.version, equals('1.11.0.0'));
-      expect(
-          tracer.schemaUrl, equals('https://opentelemetry.io/schemas/1.11.0'));
+      expect(tracer.version, isNull);
+      expect(tracer.schemaUrl, isNull);
     });
 
     test('creates span with name only', () {


### PR DESCRIPTION
## Summary

Fixes #64.

`TracerProvider.getTracer` defaulted a caller-omitted `version`/`schemaUrl`
to this package's own version constant (`1.11.0.0`) and a schema URL
the instrumented library never declared, whenever *all three* optional
parameters (`version`, `schemaUrl`, `attributes`) were omitted. That
same invented scope also fed the tracer cache key, so `getTracer('x')`
and `getTracer('x', attributes: a)` were reported as differing in
version/schemaUrl in addition to attributes — parameters the caller
never touched.

Additionally, `Tracer.startSpan` had its own fallback (`version ??
'1.0.0'`) when building the span's `InstrumentationScope`, so even
after removing the `TracerProvider`-level defaulting, spans would
still report a fabricated version. Fixed that too, along with
`InstrumentationScopeCreate.create`'s own `'1.0.0'` default (only
reachable through that one call site once the fallback above is
removed; its other two callers were already passing an explicit
version or intentionally using the no-op default for a synthetic
`noop-tracer` scope).

- `version`/`schemaUrl` now pass through as the caller gave them; a
  null stays null through `getTracer`, the tracer cache key, and the
  span's `InstrumentationScope`.
- Updated `tracer_provider_defaults_test.dart` and `tracer_test.dart`,
  which asserted the old (spec-violating) defaulting behavior.
- Added a CHANGELOG entry under the `1.0.0-rc.3-wip` section.

Per #64's note, the same defaulting pattern exists in
`logs/logger_provider.dart` and `metrics/meter_create.dart` — left
untouched here since those are tracked separately.

## Test plan
- [x] `dart analyze` — no issues
- [x] `dart test` — full suite passes (1036 tests)
- [x] New/updated tests cover: no-params case, span-level scope,
      and tracer-identity (cache key) behavior

Assisted-by: Claude Sonnet 5