### PR TITLE
fix(api): getTracer/getLogger/getMeter must not invent a scope version or schema URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **BREAKING**: Replaced the `enabled` getter with `isEnabled()` method on `APITracer`, `APILogger`, `APIInstrument` and all instrument subclasses. The `enabled` parameter has also been removed from all metric instrument creation API constructors and factories. This change allows SDKs to dynamically re-evaluate instrument enablement and enables adding parameters to `isEnabled()` in the future without breaking the API.
 
+### Fixed (spec compliance)
+- `getTracer`/`getLogger`/`getMeter` no longer invent a scope version or
+  schema URL when the caller omits them
+  ([#108](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/108)).
+
 ## [1.0.0-rc.2] - 2026-08-23
 
 ### Added

--- a/lib/src/api/common/instrumentation_scope_create.dart
+++ b/lib/src/api/common/instrumentation_scope_create.dart
@@ -17,7 +17,7 @@ class InstrumentationScopeCreate {
   /// @return A new InstrumentationScope instance
   static InstrumentationScope create({
     required String name,
-    String version = '1.0.0',
+    String? version,
     String? schemaUrl,
     Attributes? attributes,
   }) {

--- a/lib/src/api/logs/logger_provider.dart
+++ b/lib/src/api/logs/logger_provider.dart
@@ -85,27 +85,19 @@ class APILoggerProvider {
           'Invalid log name provided; using empty string as fallback.'));
     }
 
-    // Apply default values if none are provided
-    var effectiveVersion = version;
-    var effectiveSchemaUrl = schemaUrl;
-
-    // Only apply defaults if all optional parameters are missing
-    if (version == null && schemaUrl == null && attributes == null) {
-      effectiveVersion = OTelAPI.defaultServiceVersion;
-      effectiveSchemaUrl = OTelAPI.defaultSchemaUrl;
-    }
-
-    // Create a cache key based on the provided parameters.
-    final key = SignalInstanceKey(validatedName, effectiveVersion,
-        effectiveSchemaUrl, attributes, Signal.logs);
+    // Create a cache key based on the provided parameters. A caller who
+    // omits version/schemaUrl gets a logger with a null scope version and
+    // schema URL — the API must not invent values the caller never stated.
+    final key = SignalInstanceKey(
+        validatedName, version, schemaUrl, attributes, Signal.logs);
 
     if (_loggerCache.containsKey(key)) {
       return _loggerCache[key]!;
     } else {
       final logger = LoggerCreate.create(
         name: validatedName,
-        version: effectiveVersion,
-        schemaUrl: effectiveSchemaUrl,
+        version: version,
+        schemaUrl: schemaUrl,
         attributes: attributes,
       );
       _loggerCache[key] = logger;

--- a/lib/src/api/metrics/meter.dart
+++ b/lib/src/api/metrics/meter.dart
@@ -3,7 +3,6 @@
 
 import 'package:meta/meta.dart';
 import '../common/attributes.dart';
-import '../otel_api.dart';
 import 'counter.dart';
 import 'gauge.dart';
 import 'histogram.dart';

--- a/lib/src/api/metrics/meter_create.dart
+++ b/lib/src/api/metrics/meter_create.dart
@@ -23,18 +23,10 @@ class APIMeterCreate {
     String? schemaUrl,
     Attributes? attributes,
   }) {
-    // Only apply all defaults if none of version, schemaUrl, or attributes are provided
-    final setDefaults =
-        version == null && schemaUrl == null && attributes == null;
-
     return APIMeter._(
       name: name,
-      version: setDefaults
-          ? OTelAPI.defaultServiceVersion
-          : version, // Only set default if no parameters were provided
-      schemaUrl: setDefaults
-          ? OTelAPI.defaultSchemaUrl
-          : schemaUrl, // Only set default if no parameters were provided
+      version: version,
+      schemaUrl: schemaUrl,
       attributes: attributes,
     );
   }

--- a/lib/src/api/trace/tracer.dart
+++ b/lib/src/api/trace/tracer.dart
@@ -239,7 +239,7 @@ class APITracer {
       name: name,
       instrumentationScope: InstrumentationScopeCreate.create(
           name: this.name,
-          version: version ?? '1.0.0',
+          version: version,
           schemaUrl: schemaUrl,
           attributes: attributes),
       spanContext: effectiveSpanContext,

--- a/lib/src/api/trace/tracer_provider.dart
+++ b/lib/src/api/trace/tracer_provider.dart
@@ -95,27 +95,19 @@ class APITracerProvider {
           'Invalid tracer name provided; using empty string as fallback.'));
     }
 
-    // Apply default values if none are provided
-    var effectiveVersion = version;
-    var effectiveSchemaUrl = schemaUrl;
-
-    // Only apply defaults if all optional parameters are missing
-    if (version == null && schemaUrl == null && attributes == null) {
-      effectiveVersion = OTelAPI.defaultServiceVersion;
-      effectiveSchemaUrl = OTelAPI.defaultSchemaUrl;
-    }
-
-    // Create a cache key based on the provided parameters.
-    final key = SignalInstanceKey(validatedName, effectiveVersion,
-        effectiveSchemaUrl, attributes, Signal.traces);
+    // Create a cache key based on the provided parameters. A caller who
+    // omits version/schemaUrl gets a tracer with a null scope version and
+    // schema URL — the API must not invent values the caller never stated.
+    final key = SignalInstanceKey(
+        validatedName, version, schemaUrl, attributes, Signal.traces);
 
     if (_tracerCache.containsKey(key)) {
       return _tracerCache[key]!;
     } else {
       final tracer = TracerCreate.create(
         name: validatedName,
-        version: effectiveVersion,
-        schemaUrl: effectiveSchemaUrl,
+        version: version,
+        schemaUrl: schemaUrl,
         attributes: attributes,
         timeProvider: timeProvider,
       );

--- a/test/unit/api/logs/log_provider_test.dart
+++ b/test/unit/api/logs/log_provider_test.dart
@@ -217,16 +217,17 @@ void main() {
       expect(provider.getLogger('after-shutdown'), isNotNull);
     });
 
-    test('getLogger uses defaults when no optional parameters provided', () {
+    test(
+        'getLogger does not invent a scope version or schema URL when no '
+        'optional parameters are provided', () {
       final provider = OTelAPI.loggerProvider();
 
       final logger = provider.getLogger('test-lib');
 
       expect(logger, isNotNull);
       expect(logger.name, equals('test-lib'));
-      // When no parameters are provided, defaults should be applied
-      expect(logger.version, equals(OTelAPI.defaultServiceVersion));
-      expect(logger.schemaUrl, equals(OTelAPI.defaultSchemaUrl));
+      expect(logger.version, isNull);
+      expect(logger.schemaUrl, isNull);
     });
 
     test(

--- a/test/unit/api/logs/logger_test.dart
+++ b/test/unit/api/logs/logger_test.dart
@@ -21,8 +21,8 @@ void main() {
 
       expect(logger, isNotNull);
       expect(logger.name, equals('test-logger'));
-      expect(logger.version, isNotNull);
-      expect(logger.schemaUrl, isNotNull);
+      expect(logger.version, isNull);
+      expect(logger.schemaUrl, isNull);
       expect(logger.attributes, isNull);
     });
 

--- a/test/unit/api/metrics/meter_provider_defaults_test.dart
+++ b/test/unit/api/metrics/meter_provider_defaults_test.dart
@@ -19,18 +19,16 @@ void main() {
       meterProvider = OTelAPI.meterProvider();
     });
 
-    test('applies all defaults when no optional parameters are provided', () {
+    test(
+        'does not invent a scope version or schema URL when no optional '
+        'parameters are provided', () {
       // Act
       final meter = meterProvider.getMeter(name: 'test-meter');
 
       // Assert
       expect(meter.name, equals('test-meter'));
-      expect(meter.version,
-          equals('1.11.0.0')); // Default version should be applied
-      expect(
-          meter.schemaUrl,
-          equals(
-              'https://opentelemetry.io/schemas/1.11.0')); // Default schema should be applied
+      expect(meter.version, isNull);
+      expect(meter.schemaUrl, isNull);
       expect(meter.attributes, isNull);
     });
 

--- a/test/unit/api/metrics/meter_provider_test.dart
+++ b/test/unit/api/metrics/meter_provider_test.dart
@@ -26,8 +26,8 @@ void main() {
       // Assert
       expect(meter, isNotNull);
       expect(meter.name, equals('test-meter'));
-      expect(meter.version, isNotNull);
-      expect(meter.schemaUrl, isNotNull);
+      expect(meter.version, isNull);
+      expect(meter.schemaUrl, isNull);
     });
 
     test('creates meter with empty name as fallback if name is invalid', () {

--- a/test/unit/api/metrics/meter_test.dart
+++ b/test/unit/api/metrics/meter_test.dart
@@ -22,9 +22,9 @@ void main() {
     test('has correct properties', () {
       // Assert
       expect(meter.name, equals('test-meter'));
-      expect(meter.version, isNotNull);
+      expect(meter.version, isNull);
       expect(meter.isEnabled(), isFalse);
-      expect(meter.schemaUrl, isNotNull);
+      expect(meter.schemaUrl, isNull);
     });
 
     test('creates counter with valid name', () {

--- a/test/unit/api/trace/tracer_provider_defaults_test.dart
+++ b/test/unit/api/trace/tracer_provider_defaults_test.dart
@@ -19,16 +19,18 @@ void main() {
       tracerProvider = OTelAPI.tracerProvider();
     });
 
-    test('applies all defaults when no optional parameters are provided', () {
+    test(
+        'does not invent a scope version or schema URL when no optional '
+        'parameters are provided', () {
       // Act
       final tracer = tracerProvider.getTracer('test-tracer');
 
       // Assert
       expect(tracer.name, equals('test-tracer'));
-      expect(tracer.version,
-          equals('1.11.0.0')); // Default version should be applied
-      expect(tracer.schemaUrl,
-          equals(OTelAPI.defaultSchemaUrl)); // Default schema should be applied
+      // The caller stated no version or schema URL, so the API must not
+      // report the package's own version constant or a fabricated schema.
+      expect(tracer.version, isNull);
+      expect(tracer.schemaUrl, isNull);
       expect(tracer.attributes, isNull);
     });
 
@@ -86,6 +88,30 @@ void main() {
       expect(tracer.schemaUrl, isNull); // No default schema
       expect(tracer.attributes, isNotNull);
       expect(tracer.attributes!.getString('key'), equals('value'));
+    });
+
+    test(
+        'a tracer requested with only attributes is distinct only in '
+        'attributes, not in an invented version/schemaUrl', () {
+      final bare = tracerProvider.getTracer('same-name');
+      final withAttrs = tracerProvider.getTracer('same-name',
+          attributes: {'key': 'value'}.toAttributes());
+
+      expect(bare.version, isNull);
+      expect(withAttrs.version, isNull);
+      expect(bare.schemaUrl, isNull);
+      expect(withAttrs.schemaUrl, isNull);
+      expect(identical(bare, withAttrs), isFalse);
+    });
+
+    test(
+        'a span from a tracer with no version does not report an invented '
+        'instrumentation scope version', () {
+      final tracer = tracerProvider.getTracer('test-tracer');
+      final span = tracer.startSpan('test-span');
+
+      expect(span.instrumentationScope.version, isNull);
+      expect(span.instrumentationScope.schemaUrl, isNull);
     });
   });
 }

--- a/test/unit/api/trace/tracer_test.dart
+++ b/test/unit/api/trace/tracer_test.dart
@@ -28,13 +28,12 @@ void main() {
       OTelFactory.otelFactory = originalFactory;
     });
 
-    test('creates with name, version, and schemaUrl', () {
+    test('does not invent a version or schemaUrl when none are given', () {
       final tracer = OTelAPI.tracer('test-tracer');
 
       expect(tracer.name, equals('test-tracer'));
-      expect(tracer.version, equals('1.11.0.0'));
-      expect(
-          tracer.schemaUrl, equals('https://opentelemetry.io/schemas/1.11.0'));
+      expect(tracer.version, isNull);
+      expect(tracer.schemaUrl, isNull);
       expect(tracer.isEnabled(), isFalse);
     });
 


### PR DESCRIPTION
## Summary

`getTracer`/`getLogger`/`getMeter` each defaulted a caller-omitted
`version`/`schemaUrl` to this package's own version constant
(`1.11.0.0`) and a schema URL the instrumented library never
declared, whenever *all three* optional parameters (`version`,
`schemaUrl`, `attributes`) were omitted. That same invented scope also
fed each provider's instance cache key, so e.g. `getTracer('x')` and
`getTracer('x', attributes: a)` were reported as differing in
version/schemaUrl in addition to attributes — parameters the caller
never touched.

`Tracer.startSpan` had its own fallback (`version ?? '1.0.0'`) when
building the span's `InstrumentationScope`, so even after removing the
provider-level defaulting, spans would still report a fabricated
version. Fixed that too, along with `InstrumentationScopeCreate.create`'s
own `'1.0.0'` default (only reachable through that call site now; its
other two callers already pass an explicit version or intentionally
use the no-op default for a synthetic `noop-tracer` scope).

- `version`/`schemaUrl` now pass through as the caller gave them across
  Trace, Logs, and Metrics; a null stays null end to end.
- Updated the existing tests that asserted the old (spec-violating)
  defaulting behavior, across all three signals.
- CHANGELOG entry kept to one line, links back to this PR.

## Test plan
- [x] `dart analyze` — no issues
- [x] `dart test` — full suite passes

Assisted-by: Claude Sonnet 5