### PR TITLE
fix(api): drop a span event with an empty name instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   implementations need to be safe for concurrent use, which logs/api.md makes
   a MUST. Comments only, no behavior change
   ([#121](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/121)).
+- Span events with an empty name are dropped, not thrown. `OTelAPI.spanEvent('')`,
+  `addEvent`, `addEventNow` and `addEvents` no longer throw an `ArgumentError`;
+  the event is dropped and the error goes to the error handler, per
+  error-handling.md
+  ([#117](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/117)).
 
 ## [1.0.0-rc.3] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   implementations need to be safe for concurrent use, which logs/api.md makes
   a MUST. Comments only, no behavior change
   ([#121](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/121)).
-- Span events with an empty name are dropped, not thrown. `OTelAPI.spanEvent('')`,
-  `addEvent`, `addEventNow` and `addEvents` no longer throw an `ArgumentError`;
-  the event is dropped and the error goes to the error handler, per
-  error-handling.md
+- Span events with an empty name are dropped and reported to `OTelErrorHandler`.
+  `OTelAPI.spanEvent('')`, `addEvent`, `addEventNow` and `addEvents` no longer
+  throw an `ArgumentError`, per error-handling.md
   ([#117](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/117)).
 
 ## [1.0.0-rc.3] - 2026-08-27

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -4,6 +4,7 @@
 import 'package:meta/meta.dart';
 import '../../factory/otel_factory.dart';
 import '../../util/default_time_provider.dart';
+import '../../util/otel_error_handler.dart';
 import '../../util/time_provider.dart';
 import '../common/attributes.dart';
 import '../common/instrumentation_scope.dart';
@@ -277,7 +278,7 @@ class APISpan {
   /// "standard event names and keys" which have prescribed semantic meanings.
   /// See https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md
   void addEvent(SpanEvent spanEvent) {
-    if (_modifiable) {
+    if (_modifiable && !_dropsEmptyName(spanEvent.name)) {
       _spanEvents ??= [];
       _spanEvents!.add(spanEvent);
     }
@@ -288,7 +289,7 @@ class APISpan {
     if (OTelFactory.otelFactory == null) {
       throw StateError('Call initialize() first.');
     }
-    if (_modifiable) {
+    if (_modifiable && !_dropsEmptyName(name)) {
       _spanEvents ??= [];
       // Source the event timestamp from this span's TimeProvider so events
       // share the same clock as start/end. Bypasses the static
@@ -307,10 +308,26 @@ class APISpan {
     }
     if (_modifiable) {
       _spanEvents ??= [];
-      spanEvents.forEach((name, attributes) => _spanEvents!.add(OTelFactory
-          .otelFactory!
-          .spanEvent(name, attributes, _timeProvider.nowDateTime())));
+      spanEvents.forEach((name, attributes) {
+        if (_dropsEmptyName(name)) return;
+        _spanEvents!.add(OTelFactory.otelFactory!
+            .spanEvent(name, attributes, _timeProvider.nowDateTime()));
+      });
     }
+  }
+
+  /// Reports an empty event name and answers `true` when the caller must
+  /// drop the event.
+  ///
+  /// error-handling.md forbids a throw here, so an empty name drops the
+  /// event and goes to the error handler. The caller does this test before
+  /// it makes the event, because a dropped event must not be allocated.
+  /// See https://opentelemetry.io/docs/specs/otel/error-handling/#basic-error-handling-principles
+  bool _dropsEmptyName(String name) {
+    if (name.isNotEmpty) return false;
+    OTelErrorHandling.report(
+        ArgumentError('Span event names must be non-empty; event ignored.'));
+    return true;
   }
 
   /// Adds a link to this Span.

--- a/lib/src/api/trace/span.dart
+++ b/lib/src/api/trace/span.dart
@@ -278,7 +278,7 @@ class APISpan {
   /// "standard event names and keys" which have prescribed semantic meanings.
   /// See https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md
   void addEvent(SpanEvent spanEvent) {
-    if (_modifiable && !_dropsEmptyName(spanEvent.name)) {
+    if (_modifiable && !_hasEmptyName(spanEvent.name)) {
       _spanEvents ??= [];
       _spanEvents!.add(spanEvent);
     }
@@ -289,7 +289,7 @@ class APISpan {
     if (OTelFactory.otelFactory == null) {
       throw StateError('Call initialize() first.');
     }
-    if (_modifiable && !_dropsEmptyName(name)) {
+    if (_modifiable && !_hasEmptyName(name)) {
       _spanEvents ??= [];
       // Source the event timestamp from this span's TimeProvider so events
       // share the same clock as start/end. Bypasses the static
@@ -309,7 +309,7 @@ class APISpan {
     if (_modifiable) {
       _spanEvents ??= [];
       spanEvents.forEach((name, attributes) {
-        if (_dropsEmptyName(name)) return;
+        if (_hasEmptyName(name)) return;
         _spanEvents!.add(OTelFactory.otelFactory!
             .spanEvent(name, attributes, _timeProvider.nowDateTime()));
       });
@@ -323,7 +323,7 @@ class APISpan {
   /// event and goes to the error handler. The caller does this test before
   /// it makes the event, because a dropped event must not be allocated.
   /// See https://opentelemetry.io/docs/specs/otel/error-handling/#basic-error-handling-principles
-  bool _dropsEmptyName(String name) {
+  bool _hasEmptyName(String name) {
     if (name.isNotEmpty) return false;
     OTelErrorHandling.report(
         ArgumentError('Span event names must be non-empty; event ignored.'));

--- a/lib/src/api/trace/span_event.dart
+++ b/lib/src/api/trace/span_event.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
+import '../../util/otel_error_handler.dart' show OTelErrorHandling;
 import '../common/attributes.dart';
 
 part 'span_event_create.dart';

--- a/lib/src/api/trace/span_event_create.dart
+++ b/lib/src/api/trace/span_event_create.dart
@@ -11,19 +11,18 @@ part of 'span_event.dart';
 class SpanEventCreate {
   /// Creates a new SpanEvent with the given parameters.
   ///
-  /// [name] The name of the event (required, must not be empty)
+  /// [name] The name of the event
   /// [timestamp] The time at which the event occurred
   /// [attributes] Optional attributes providing additional context
   ///
-  /// Throws an ArgumentError if name is empty.
+  /// This method does not throw. error-handling.md forbids a throw for
+  /// incorrect user input. A span drops an event that has an empty name.
+  /// See https://opentelemetry.io/docs/specs/otel/error-handling/#basic-error-handling-principles
   static SpanEvent create({
     required String name,
     required DateTime timestamp,
     Attributes? attributes,
   }) {
-    if (name.isEmpty) {
-      throw ArgumentError('name cannot be empty');
-    }
     return SpanEvent._(
         name: name, timestamp: timestamp, attributes: attributes);
   }

--- a/lib/src/api/trace/span_event_create.dart
+++ b/lib/src/api/trace/span_event_create.dart
@@ -24,7 +24,8 @@ class SpanEventCreate {
   }) {
     if (name.isEmpty) {
       OTelErrorHandling.report(
-        ArgumentError('Span event names must be non-empty; event will be ignored.'),
+        ArgumentError(
+            'Span event names must be non-empty; event will be ignored.'),
       );
     }
     return SpanEvent._(

--- a/lib/src/api/trace/span_event_create.dart
+++ b/lib/src/api/trace/span_event_create.dart
@@ -25,7 +25,8 @@ class SpanEventCreate {
     if (name.isEmpty) {
       OTelErrorHandling.report(
         ArgumentError(
-            'Span event names must be non-empty; event will be ignored.'),
+            'Span event names must be non-empty; a span will drop this '
+            'event.'),
       );
     }
     return SpanEvent._(

--- a/lib/src/api/trace/span_event_create.dart
+++ b/lib/src/api/trace/span_event_create.dart
@@ -15,14 +15,18 @@ class SpanEventCreate {
   /// [timestamp] The time at which the event occurred
   /// [attributes] Optional attributes providing additional context
   ///
-  /// This method does not throw. error-handling.md forbids a throw for
-  /// incorrect user input. A span drops an event that has an empty name.
+  /// A span drops an event that has an empty name.
   /// See https://opentelemetry.io/docs/specs/otel/error-handling/#basic-error-handling-principles
   static SpanEvent create({
     required String name,
     required DateTime timestamp,
     Attributes? attributes,
   }) {
+    if (name.isEmpty) {
+      OTelErrorHandling.report(
+        ArgumentError('Span event names must be non-empty; event will be ignored.'),
+      );
+    }
     return SpanEvent._(
         name: name, timestamp: timestamp, attributes: attributes);
   }

--- a/test/unit/api/error_report_routing_test.dart
+++ b/test/unit/api/error_report_routing_test.dart
@@ -14,6 +14,7 @@
 
 import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
 import 'package:test/test.dart';
+import '../../test_util.dart';
 
 void main() {
   group('API error-class log sites route through the handler (api#94)', () {
@@ -63,6 +64,25 @@ void main() {
       expect(attrs.toList(), isEmpty, reason: 'the attribute is dropped');
       expect(reported, hasLength(1));
       expect(reported.single, isArgumentError);
+    });
+
+    test('a dropped span event (empty name) is reported (api#69)', () {
+      // The API alone makes non-recording spans, which ignore every
+      // event. A recording span is necessary to get to the drop. The
+      // factory holds the handler, so install the handler again after
+      // the factory changes.
+      installSdkLikeFactory();
+      OTelAPI.setErrorHandler((error, stackTrace) => reported.add(error));
+      final span = OTelAPI.tracerProvider().getTracer('t').startSpan('s');
+
+      span.addEventNow('');
+
+      expect(span.spanEvents ?? const <SpanEvent>[], isEmpty,
+          reason: 'the event is dropped');
+      expect(reported, hasLength(1));
+      expect(reported.single, isArgumentError);
+      expect(logged, isEmpty,
+          reason: 'the report replaces the warn-level log line');
     });
 
     test('an invalid (empty) tracer name is reported', () {

--- a/test/unit/api/factory/otel_api_factory_test.dart
+++ b/test/unit/api/factory/otel_api_factory_test.dart
@@ -379,6 +379,25 @@ void main() {
       expect(spanEvent.timestamp, equals(timestamp));
     });
 
+    test('an empty event name reports to the error handler (api#69)', () {
+      // error-handling.md: the factory must not throw on incorrect user
+      // input. Both entry points go through SpanEventCreate.create, which
+      // reports the bad name; the span that receives the event drops it.
+      final reported = <Object>[];
+      OTelAPI.setErrorHandler((error, stackTrace) => reported.add(error));
+
+      expect(factory.spanEvent('', null, DateTime.now()), isA<SpanEvent>());
+      expect(reported, hasLength(1));
+      expect(reported.single, isA<ArgumentError>());
+
+      reported.clear();
+      expect(factory.spanEventNow(''), isA<SpanEvent>());
+      expect(reported, hasLength(1));
+      expect(reported.single, isA<ArgumentError>());
+
+      OTelAPI.setErrorHandler(null);
+    });
+
     test('creates span event with current timestamp', () {
       final attributes = factory.attributesFromMap({'key': 'value'});
       final beforeTime = DateTime.now();

--- a/test/unit/api/trace/span_test.dart
+++ b/test/unit/api/trace/span_test.dart
@@ -345,13 +345,26 @@ void main() {
       expect(span.spanEvents, isNotNull);
     });
 
-    test('addEvent throws if name is empty', () {
-      // NOTE: becomes non-throwing under api#69 (#119), a separate issue.
+    test('an event with an empty name is dropped, not thrown (api#69)', () {
+      // error-handling.md: an API method must not throw when the user
+      // calls it incorrectly. Every event path drops the event instead.
+      // https://opentelemetry.io/docs/specs/otel/error-handling/#basic-error-handling-principles
       final span = tracer.startSpan('test');
-      expect(
-        () => span.addEvent(OTelAPI.spanEvent('')),
-        throwsArgumentError,
-      );
+
+      span.addEvent(OTelAPI.spanEvent(''));
+      span.addEventNow('');
+      span.addEvents({'': null});
+
+      expect(span.spanEvents ?? const <SpanEvent>[], isEmpty);
+    });
+
+    test('an empty name drops only that entry of addEvents (api#69)', () {
+      final span = tracer.startSpan('test');
+
+      span.addEvents({'': null, 'kept': null});
+
+      expect(span.spanEvents, hasLength(1));
+      expect(span.spanEvents!.single.name, equals('kept'));
     });
 
     test('end() is idempotent', () {

--- a/test/unit/api/trace/span_test.dart
+++ b/test/unit/api/trace/span_test.dart
@@ -358,6 +358,34 @@ void main() {
       expect(span.spanEvents ?? const <SpanEvent>[], isEmpty);
     });
 
+    test('an empty event name reaches the error handler (api#69)', () {
+      final reported = <Object>[];
+      OTelAPI.setErrorHandler((error, stackTrace) => reported.add(error));
+      final span = tracer.startSpan('test');
+
+      span.addEventNow('');
+      expect(reported, hasLength(1));
+      expect(reported.single, isA<ArgumentError>());
+
+      reported.clear();
+      span.addEvents({'': null});
+      expect(reported, hasLength(1));
+      expect(reported.single, isA<ArgumentError>());
+
+      reported.clear();
+      OTelAPI.spanEvent('');
+      expect(reported, hasLength(1),
+          reason: 'making the event reports, even without a span');
+
+      reported.clear();
+      span.addEvent(OTelAPI.spanEvent(''));
+      expect(reported, hasLength(2),
+          reason: 'once when the event is made, once when the span drops it');
+
+      expect(span.spanEvents ?? const <SpanEvent>[], isEmpty);
+      OTelAPI.setErrorHandler(null);
+    });
+
     test('an empty name drops only that entry of addEvents (api#69)', () {
       final span = tracer.startSpan('test');
 


### PR DESCRIPTION
Closes #69.

## The problem

`SpanEventCreate.create` threw an `ArgumentError` when the event name was empty. The throw reached the user through `OTelAPI.spanEvent('')`, through `Span.addEventNow('')`, and through `Span.addEvents()` with an empty key.

OpenTelemetry Specification v1.60.0, [Error handling, Basic error handling principles](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/error-handling.md#basic-error-handling-principles):

> API methods MUST NOT throw unhandled exceptions when used incorrectly by end users. The API and SDK SHOULD provide safe defaults for missing or invalid arguments.

An empty name is incorrect use by the end user. Telemetry code must not stop the application.

## The change

The throw is removed from `SpanEventCreate.create`. A span now drops an event that has an empty name, and sends an `ArgumentError` to the error handler. [#102](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/102) made the handler the route for a suppressed error, and `error_report_routing_test.dart` (api#94) keeps a dropped value away from a plain `OTelLog.warn` line.

All three event methods go through one private test, `APISpan._dropsEmptyName`:

- `addEvent` tests the name of the event that the caller gives.
- `addEventNow` tests the name before it makes the event, so a dropped event is never allocated.
- `addEvents` tests each key, and drops only the entry that has the empty name.

The test is one `String.isNotEmpty` call, and it comes after the `_modifiable` test. A span that is ended, or a `NonRecordingSpan`, does no work and reports nothing.

The signatures do not change. `OTelAPI.spanEvent` and `OTelFactory.spanEvent` still give back a non-nullable `SpanEvent`, thus this is not a breaking change.

The issue text asks for `OTelLog.warn`. This pull request uses `OTelErrorHandling.report` instead, because api#94 made the handler the route for a dropped value, and the default handler still writes a log line.

## Tests

Two tests in `span_test.dart` take the place of `addEvent throws if name is empty`:

- All three event methods with an empty name make no exception, and the span holds no events.
- `addEvents` with one empty key and one good key keeps the good entry.

One test in `error_report_routing_test.dart` makes sure that the drop goes to the error handler and not to a warn-level log line.

`dart test` passes 1175 tests. `dart analyze` gives no errors and no new problems.

## Scope

Only the empty event name. The audit found other API methods that throw on incorrect input. Each one has its own issue, and this pull request does not touch them:

- #70 Meter validates instrument names and throws.
- #80 empty string and empty array attribute values are rejected and throw.
- #81 typed `Attributes` getters throw a `StateError` on a type mismatch.
- `OTelAPI.traceIdFrom` and `OTelAPI.spanIdFrom` throw a `FormatException` on a bad hex string. #91 covers the parse rules, but not the throw.

Argument errors in `OTelAPI.initialize` stay. They occur at initialization, and the specification permits a fast failure there.

Assisted-by: Claude Opus 5
