### PR TITLE
fix: validate TraceState keys/values during construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed (spec compliance)
 
+- `TraceState` construction (`fromMap`, `OTelAPI`/`OTelFactory` `traceState(...)`)
+  now validates keys and values against the W3C tracestate grammar, dropping
+  invalid entries instead of silently accepting them
+  ([#119](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/119)).
 - **BREAKING**: `IdGenerator.hexToBytes`, and so `OTelAPI.traceIdFrom` and
   `OTelAPI.spanIdFrom`, no longer accept anything outside lowercase hex
   ([#112](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/112)).

--- a/lib/src/api/trace/trace_state_create.dart
+++ b/lib/src/api/trace/trace_state_create.dart
@@ -6,29 +6,24 @@ part of 'trace_state.dart';
 /// Internal constructor access for TraceState
 @internal
 class TraceStateCreate {
-  /// Creates a TraceState, only accessible within library
-  /// Enforces 32 key-value pair limit per W3C spec
+  /// Drops invalid entries; keeps at most 32.
   static TraceState create(Map<String, String>? entries) {
     if (entries == null || entries.isEmpty) {
       return TraceState._({});
     }
 
-    // Enforce 32 key-value pair limit
-    if (entries.length > 32) {
-      // Take only the first 32 entries
-      final limitedEntries = <String, String>{};
-      var count = 0;
-
-      for (final entry in entries.entries) {
-        if (count >= 32) break;
-
-        limitedEntries[entry.key] = entry.value;
-        count++;
+    final validEntries = <String, String>{};
+    for (final entry in entries.entries) {
+      if (validEntries.length >= 32) break;
+      if (TraceState._isValidKey(entry.key) &&
+          TraceState._isValidValue(entry.value)) {
+        validEntries[entry.key] = entry.value;
+      } else {
+        OTelErrorHandling.report(ArgumentError(
+            'Invalid TraceState key or value: "${entry.key}"; entry dropped.'));
       }
-
-      return TraceState._(limitedEntries);
     }
 
-    return TraceState._(entries);
+    return TraceState._(validEntries);
   }
 }

--- a/lib/src/api/trace/trace_state_create.dart
+++ b/lib/src/api/trace/trace_state_create.dart
@@ -6,7 +6,10 @@ part of 'trace_state.dart';
 /// Internal constructor access for TraceState
 @internal
 class TraceStateCreate {
-  /// Drops invalid entries; keeps at most 32.
+  /// Creates a TraceState, only accessible within library.
+  /// Enforces the W3C 32 key-value pair limit. Entries with an invalid key
+  /// or value are dropped and reported via [OTelErrorHandling.report]
+  /// rather than throwing, per trace/api.md.
   static TraceState create(Map<String, String>? entries) {
     if (entries == null || entries.isEmpty) {
       return TraceState._({});

--- a/test/unit/api/trace/span_context_test.dart
+++ b/test/unit/api/trace/span_context_test.dart
@@ -270,11 +270,11 @@ void main() {
         isRemote: false,
       );
 
-      final newState = TraceState.fromMap({'newVendor': 'newValue'});
+      final newState = TraceState.fromMap({'newvendor': 'newValue'});
       final updatedContext = originalContext.withTraceState(newState);
 
       // Verify new context has updated state
-      expect(updatedContext.traceState!.get('newVendor'), equals('newValue'));
+      expect(updatedContext.traceState!.get('newvendor'), equals('newValue'));
       // Verify other fields are preserved
       expect(updatedContext.traceId, equals(traceId));
       expect(updatedContext.spanId, equals(spanId));

--- a/test/unit/api/trace/trace_state_spec_compliance_test.dart
+++ b/test/unit/api/trace/trace_state_spec_compliance_test.dart
@@ -47,6 +47,24 @@ void main() {
     });
   });
 
+  group('TraceState construction drops invalid entries', () {
+    test('fromMap drops an entry with an invalid key', () {
+      final result = TraceState.fromMap({'BadKey': 'a', 'goodkey': 'b'});
+      expect(result.entries, equals({'goodkey': 'b'}));
+    });
+
+    test('fromMap drops an entry with an invalid value', () {
+      final result = TraceState.fromMap({'vendor': 'a,b=c', 'goodkey': 'b'});
+      expect(result.entries, equals({'goodkey': 'b'}));
+    });
+
+    test('fromMap never produces a TraceState containing invalid data', () {
+      final result = TraceState.fromMap({'BadKey': 'a,b=c'});
+      expect(result.entries, isEmpty);
+      expect(result.toString(), isEmpty);
+    });
+  });
+
   group('TraceState works without an installed SDK', () {
     test('put works after reset', () {
       final traceState = TraceState.fromMap({'vendor': 'value'});

--- a/test/unit/api/trace/trace_state_spec_compliance_test.dart
+++ b/test/unit/api/trace/trace_state_spec_compliance_test.dart
@@ -63,6 +63,27 @@ void main() {
       expect(result.entries, isEmpty);
       expect(result.toString(), isEmpty);
     });
+
+    test('fromMap drops a key over 256 characters', () {
+      final result = TraceState.fromMap({'a' * 257: 'value', 'goodkey': 'b'});
+      expect(result.entries, equals({'goodkey': 'b'}));
+    });
+
+    test('fromMap drops a value over 256 characters', () {
+      final result = TraceState.fromMap({'vendor': 'a' * 257, 'goodkey': 'b'});
+      expect(result.entries, equals({'goodkey': 'b'}));
+    });
+
+    test('fromMap reports a dropped entry to the error handler', () {
+      final reported = <Object>[];
+      OTelAPI.setErrorHandler((error, stackTrace) => reported.add(error));
+      addTearDown(OTelErrorHandling.resetToDefault);
+
+      TraceState.fromMap({'BadKey': 'a,b=c'});
+
+      expect(reported, hasLength(1));
+      expect(reported.single, isArgumentError);
+    });
   });
 
   group('TraceState works without an installed SDK', () {

--- a/test/unit/api/trace/trace_state_test.dart
+++ b/test/unit/api/trace/trace_state_test.dart
@@ -84,7 +84,7 @@ void main() {
       }
 
       final traceState = TraceState.fromMap(entries);
-      expect(traceState.entries.length <= 32, isTrue);
+      expect(traceState.entries.length, equals(32));
     });
 
     test('gets value for key', () {


### PR DESCRIPTION
## Summary
- `TraceStateCreate.create` (the single choke point behind `TraceState.fromMap`, `TraceState.empty()`, and the `OTelAPI`/`OTelFactory` `traceState(...)` factories) only enforced the 32-entry limit; `put()` was the only mutator that validated keys/values against the W3C tracestate grammar.
- `TraceState.fromMap({'BadKey': 'a,b=c'})` could therefore produce a `TraceState` that serializes to a corrupt `tracestate` header.
- `create` now validates each entry with the existing `TraceState._isValidKey`/`_isValidValue` checks, drops invalid entries, and reports them via `OTelErrorHandling.report` (same path `put()` uses), while still capping at 32 entries.

Fixes #62.

## Test plan
- [x] `dart analyze` — clean
- [x] `dart test` — full suite passes (1176 tests), 100% coverage maintained
- [x] Added `TraceState construction drops invalid entries` test group covering invalid key, invalid value, and full round-trip
- [x] Fixed a pre-existing test (`span_context_test.dart`) that unknowingly relied on the bug via an uppercase key (`'newVendor'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)