### PR TITLE
chore: add @robert-northmind as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # Maintainer review is required on every PR.
-* @michaelbushe
+# Any one of the maintainers listed here satisfies that requirement.
+* @michaelbushe @robert-northmind


### PR DESCRIPTION
Adds @robert-northmind alongside me as a code owner on both repos, so his review satisfies the required code-owner approval on `main`.

GitHub accepts an approval from any one owner listed on a matching line, so either of us can clear a PR alone. A code owner still cannot approve their own PR, so our own PRs keep getting a second pair of eyes.

Paired with two settings changes already applied: `robert-northmind` added to the `main` branch push restriction, and his repo role raised to Maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3LcZp1QRqoTrKB6PnaJ1Y