### PR TITLE
[API] feat: implement AnyValue attribute hierarchy and strict compliance (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-rc.4-wip]
 
+### Changed
+
+- **BREAKING**: Replaced generic `Attribute<T>` with a concrete `Attribute` class containing an `AnyValue` payload. If you were instantiating `Attribute` directly (bypassing the factory), you must now wrap your value in the appropriate `AnyValue` subclass.
+  ([#95](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/95))
+- **BREAKING**: Strict OpenTelemetry spec compliance for attributes (`attrsFromMap` / `AnyValue.fromObject`). The previous permissive behavior of silently converting unsupported objects via `.toString()` is removed. Attributes built via `attrsFromMap` for values that previously silently stringified (e.g. custom objects) will now be silently dropped from the resulting `Attributes` and reported via `OTelErrorHandling`. `DateTime` values are natively supported and converted to UTC ISO-8601 strings.
+  ([#95](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/95))
+- **BREAKING**: `LogRecord.body` and `APILogger.emit(body: ...)` now use `AnyValue?` instead of `Object?` for strong spec compliance. Replace direct object passing with `AnyValue.fromObject(...)` or a specific subclass like `AnyValueString(...)`.
+  ([#95](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/95))
 ## [1.0.0-rc.3] - 2026-08-27
 
 ### Changed

--- a/example/dartastic_opentelemetry_api_example.dart
+++ b/example/dartastic_opentelemetry_api_example.dart
@@ -127,12 +127,14 @@ void main() {
     final logger = defaultGlobalAPINOOPLoggerProvider
         .getLogger('dart-otel-api-example-service');
 
-    logger.emit(eventName: 'heartbeat', body: 'Service is healthy.');
+    logger.emit(
+        eventName: 'heartbeat',
+        body: AnyValue.fromObject('Service is healthy.'));
 
     logger.emit(
       eventName: 'user_login',
       severityNumber: Severity.INFO,
-      body: 'User successfully logged in.',
+      body: AnyValue.fromObject('User successfully logged in.'),
       attributes: OTelAPI.attributesFromSemanticMap({
         User.userId: 42,
         ExampleAttribute.authMethod: 'password',
@@ -142,7 +144,7 @@ void main() {
     logger.emit(
       eventName: 'cache_miss',
       severityText: 'WARN',
-      body: 'Cache miss for requested key.',
+      body: AnyValue.fromObject('Cache miss for requested key.'),
       attributes: OTelAPI.attributesFromSemanticMap({
         ExampleAttribute.cacheKey: 'profile_42',
         ExampleAttribute.cacheRegion: 'us-east-1',
@@ -158,7 +160,7 @@ void main() {
     logger.emit(
       eventName: 'order_update',
       severityNumber: Severity.INFO,
-      body: 'Order update completed.',
+      body: AnyValue.fromObject('Order update completed.'),
       attributes: attrs,
     );
 
@@ -168,11 +170,11 @@ void main() {
       // Body is a user-defined structure (per the OTel logs spec) — its
       // inner keys are not span/log attributes, so they don't go through
       // an OTelSemantic enum.
-      body: [
+      body: AnyValue.fromObject([
         {'job': 'resize_images', 'status': 'ok'},
         {'job': 'generate_thumbnails', 'status': 'ok'},
         {'job': 'sync_metadata', 'status': 'failed'},
-      ],
+      ]),
       attributes: OTelAPI.attributesFromSemanticMap({
         ExampleAttribute.batchId: 'batch-2025-11-15-01',
         ExampleAttribute.jobsTotal: 3,
@@ -182,7 +184,7 @@ void main() {
     logger.emit(
       eventName: 'payment_failure',
       severityText: 'ERROR',
-      body: 'Payment could not be processed.',
+      body: AnyValue.fromObject('Payment could not be processed.'),
       attributes: OTelAPI.attributesFromSemanticMap({
         ExampleAttribute.paymentUserId: 101,
         ExampleAttribute.paymentMethod: 'credit_card',

--- a/lib/dartastic_opentelemetry_api.dart
+++ b/lib/dartastic_opentelemetry_api.dart
@@ -15,6 +15,7 @@ library;
 export 'src/api/baggage/baggage.dart' hide BaggageCreate;
 export 'src/api/baggage/baggage_entry.dart';
 // Common
+export 'src/api/common/any_value.dart';
 export 'src/api/common/attribute.dart' hide AttributeCreate;
 export 'src/api/common/attributes.dart' hide AttributesCreate;
 export 'src/api/common/instrumentation_scope.dart'

--- a/lib/src/api/common/any_value.dart
+++ b/lib/src/api/common/any_value.dart
@@ -1,0 +1,203 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
+
+/// Represents a value of any type supported by the OpenTelemetry specification.
+@immutable
+sealed class AnyValue {
+  const AnyValue();
+
+  /// Returns the underlying Dart object (not recursively unwrapped).
+  Object? get value;
+
+  Object? unwrap() {
+    return switch (this) {
+      AnyValueNull() => null,
+      AnyValueString(value: final v) => v,
+      AnyValueBool(value: final v) => v,
+      AnyValueInt(value: final v) => v,
+      AnyValueDouble(value: final v) => v,
+      AnyValueArray(value: final v) => v.map((e) => e.unwrap()).toList(),
+      AnyValueMap(value: final v) =>
+        v.map((k, val) => MapEntry(k, val.unwrap())),
+      AnyValueBytes(value: final v) => v,
+    };
+  }
+
+  /// Implements JSON serialization.
+  Object? toJson() => unwrap();
+
+  /// Creates an AnyValue from a String.
+  factory AnyValue.fromString(String value) = AnyValueString;
+
+  /// Creates an AnyValue from a boolean.
+  factory AnyValue.fromBool(bool value) = AnyValueBool;
+
+  /// Creates an AnyValue from an integer.
+  factory AnyValue.fromInt(int value) = AnyValueInt;
+
+  /// Creates an AnyValue from a double.
+  factory AnyValue.fromDouble(double value) = AnyValueDouble;
+
+  /// Creates an AnyValue from a List of AnyValues.
+  factory AnyValue.fromList(List<AnyValue> value) = AnyValueArray;
+
+  /// Creates an AnyValue from a Map of String to AnyValue.
+  factory AnyValue.fromMap(Map<String, AnyValue> value) = AnyValueMap;
+
+  /// Creates an AnyValue from a byte array.
+  factory AnyValue.fromBytes(List<int> value) = AnyValueBytes;
+
+  /// Creates an empty or null AnyValue.
+  factory AnyValue.empty() = AnyValueNull;
+
+  /// Creates an AnyValue by recursively converting a standard Dart object.
+  ///
+  /// Throws [ArgumentError] if it encounters an unsupported type.
+  factory AnyValue.fromObject(dynamic obj) {
+    if (obj == null) {
+      return const AnyValueNull();
+    } else if (obj is String) {
+      return AnyValueString(obj);
+    } else if (obj is bool) {
+      return AnyValueBool(obj);
+    } else if (obj is int) {
+      return AnyValueInt(obj);
+    } else if (obj is double) {
+      return AnyValueDouble(obj);
+    } else if (obj is List) {
+      return AnyValueArray(obj.map(AnyValue.fromObject).toList());
+    } else if (obj is Map) {
+      final map = <String, AnyValue>{};
+      obj.forEach((key, val) {
+        if (key is! String) {
+          throw ArgumentError(
+              'AnyValue map keys must be Strings, got ${key.runtimeType}');
+        }
+        map[key] = AnyValue.fromObject(val);
+      });
+      return AnyValueMap(map);
+    } else if (obj is DateTime) {
+      return AnyValueString(obj.toUtc().toIso8601String());
+    } else {
+      throw ArgumentError(
+          'Unsupported type in AnyValue conversion: ${obj.runtimeType}');
+    }
+  }
+}
+
+class AnyValueNull extends AnyValue {
+  const AnyValueNull();
+
+  @override
+  Object? get value => null;
+
+  @override
+  int get hashCode => null.hashCode;
+
+  @override
+  bool operator ==(Object other) => other is AnyValueNull;
+}
+
+class AnyValueString extends AnyValue {
+  @override
+  final String value;
+
+  const AnyValueString(this.value);
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnyValueString && value == other.value;
+}
+
+class AnyValueBool extends AnyValue {
+  @override
+  final bool value;
+
+  const AnyValueBool(this.value);
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnyValueBool && value == other.value;
+}
+
+class AnyValueInt extends AnyValue {
+  @override
+  final int value;
+
+  const AnyValueInt(this.value);
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnyValueInt && value == other.value;
+}
+
+class AnyValueDouble extends AnyValue {
+  @override
+  final double value;
+
+  const AnyValueDouble(this.value);
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnyValueDouble && value == other.value;
+}
+
+class AnyValueArray extends AnyValue {
+  @override
+  final List<AnyValue> value;
+
+  const AnyValueArray(this.value);
+
+  @override
+  int get hashCode => const DeepCollectionEquality().hash(value);
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnyValueArray &&
+      const DeepCollectionEquality().equals(value, other.value);
+}
+
+class AnyValueMap extends AnyValue {
+  @override
+  final Map<String, AnyValue> value;
+
+  const AnyValueMap(this.value);
+
+  @override
+  int get hashCode => const DeepCollectionEquality().hash(value);
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnyValueMap &&
+      const DeepCollectionEquality().equals(value, other.value);
+}
+
+class AnyValueBytes extends AnyValue {
+  @override
+  final List<int> value;
+
+  const AnyValueBytes(this.value);
+
+  @override
+  int get hashCode => const DeepCollectionEquality().hash(value);
+
+  @override
+  bool operator ==(Object other) =>
+      other is AnyValueBytes &&
+      const DeepCollectionEquality().equals(value, other.value);
+}

--- a/lib/src/api/common/attribute.dart
+++ b/lib/src/api/common/attribute.dart
@@ -1,74 +1,49 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
+
+import 'any_value.dart';
 
 part 'attribute_create.dart';
 
 /// Represents a value for an attribute, associated with an attribute key.
 @immutable
-class Attribute<T extends Object> {
-  /// The DeepCollectionEquality object used for comparing list values.
-  /// This enables proper element-by-element comparisons for lists.
-  static final DeepCollectionEquality _listEquality =
-      const DeepCollectionEquality();
-
+class Attribute {
   /// The key (name) of this attribute.
   final String _key;
 
   /// The value of this attribute.
-  final T _value;
+  final AnyValue _value;
 
-  Attribute._(String key, T value)
+  Attribute._(String key, AnyValue value)
       : _key = key,
-        _value = value {
-    if (_value is String && (_value as String).isEmpty) {
-      throw ArgumentError('Attribute _value must not be an empty string');
-    }
-    if (_value is List) {
-      final valueList = _value as List;
-      if (valueList.isEmpty) {
-        throw ArgumentError('Attribute _value list must not be empty');
-      }
-      // No null-element guard: attributes are only created with
-      // non-nullable element types (List<String>, List<bool>, List<int>,
-      // List<double>), so sound null safety already rules nulls out.
-    }
-  }
+        _value = value;
 
   /// Gets the key (name) of this attribute.
   String get key => _key;
 
   /// Gets the value of this attribute.
-  T get value => _value;
+  AnyValue get value => _value;
 
   @override
   String toString() {
-    return 'AttributeValue($_value)';
+    return 'AttributeValue(${_value.value})';
   }
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
 
-    if (other is! Attribute<T>) return false;
-
-    // Use deep equality for lists, otherwise default equality
-    final valuesAreEqual = value is List
-        ? _listEquality.equals(value, other.value)
-        : value == other.value;
+    if (other is! Attribute) return false;
 
     return runtimeType == other.runtimeType &&
         key == other.key &&
-        valuesAreEqual;
+        value == other.value;
   }
 
   @override
   int get hashCode {
-    // Use deep hash for lists, otherwise default hash
-    final valueHash =
-        value is List ? _listEquality.hash(value) : value.hashCode;
-    return Object.hash(key, valueHash);
+    return Object.hash(key, value);
   }
 }

--- a/lib/src/api/common/attribute_create.dart
+++ b/lib/src/api/common/attribute_create.dart
@@ -13,7 +13,7 @@ class AttributeCreate {
   /// @param name The name of the attribute
   /// @param value The value of the attribute
   /// @return A new Attribute instance
-  static Attribute<T> create<T extends Object>(String name, T value) {
+  static Attribute create(String name, AnyValue value) {
     return Attribute._(name, value);
   }
 }

--- a/lib/src/api/common/attributes.dart
+++ b/lib/src/api/common/attributes.dart
@@ -9,6 +9,7 @@ import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import '../../factory/otel_factory.dart';
 import '../../util/otel_error_handler.dart';
+import 'any_value.dart';
 import 'attribute.dart';
 
 part 'attributes_create.dart';
@@ -17,7 +18,7 @@ part 'attributes_create.dart';
 /// Create with the OTelFactory methods.
 @immutable
 class Attributes {
-  final Map<String, Attribute<Object>> _entries = {};
+  final Map<String, Attribute> _entries = {};
 
   /// Creates an Attributes instance from a map of key-value pairs.
   /// Uses the appropriate factory method (OTelFactory or OTelAPIFactory) based on initialization state.
@@ -31,58 +32,15 @@ class Attributes {
   /// Creates an Attributes instance from a JSON map.
   /// This is a utility method for deserialization from logs or exports.
   static Attributes fromJson(Map<String, dynamic> json) {
-    final attributes = <Attribute<Object>>[];
+    final attributes = <Attribute>[];
 
     for (final entry in json.entries) {
-      final key = entry.key;
-      final value = entry.value;
-
-      if (value is String) {
-        attributes.add(AttributeCreate.create<String>(key, value));
-      } else if (value is bool) {
-        attributes.add(AttributeCreate.create<bool>(key, value));
-      } else if (value is int) {
-        attributes.add(AttributeCreate.create<int>(key, value));
-      } else if (value is double) {
-        attributes.add(AttributeCreate.create<double>(key, value));
-      } else if (value is List<String>) {
-        attributes.add(AttributeCreate.create<List<String>>(key, value));
-      } else if (value is List<bool>) {
-        attributes.add(AttributeCreate.create<List<bool>>(key, value));
-      } else if (value is List<int>) {
-        attributes.add(AttributeCreate.create<List<int>>(key, value));
-      } else if (value is List<double>) {
-        attributes.add(AttributeCreate.create<List<double>>(key, value));
-      } else if (value is List) {
-        // Try to convert the list to a supported type
-        if (value.isNotEmpty) {
-          if (value.every((e) => e is String)) {
-            attributes.add(AttributeCreate.create<List<String>>(
-                key, value.cast<String>()));
-          } else if (value.every((e) => e is bool)) {
-            attributes.add(
-                AttributeCreate.create<List<bool>>(key, value.cast<bool>()));
-          } else if (value.every((e) => e is int)) {
-            attributes
-                .add(AttributeCreate.create<List<int>>(key, value.cast<int>()));
-          } else if (value.every((e) => e is double || e is int)) {
-            // Convert all to double
-            attributes.add(AttributeCreate.create<List<double>>(
-                key,
-                value
-                    .map((e) => e is int ? e.toDouble() : e as double)
-                    .toList()));
-          } else {
-            OTelErrorHandling.report(ArgumentError(
-                'Ignoring attribute $key because the list contains unsupported types. Only String, bool, int, double lists are allowed by the OTel specification.'));
-          }
-        } else {
-          OTelErrorHandling.report(ArgumentError(
-              'Ignoring attribute $key because empty lists are not allowed by the OTel specification.'));
-        }
-      } else {
+      try {
+        final anyValue = AnyValue.fromObject(entry.value);
+        attributes.add(AttributeCreate.create(entry.key, anyValue));
+      } catch (e) {
         OTelErrorHandling.report(ArgumentError(
-            'Ignoring attribute $key because the value is not a valid attribute type. Only String, bool, int, double and Lists of those types are allowed by the OTel specification.'));
+            'Ignoring attribute ${entry.key} because it contains unsupported types: $e'));
       }
     }
 
@@ -149,12 +107,41 @@ class Attributes {
     final attribute = _entries[key];
     if (attribute == null) return null;
 
-    // Ensure the value matches the expected type `T`
-    if (attribute.value is T) {
-      return attribute.value as T;
-    } else {
-      throw StateError('Value for key "$key" is not of type $T');
+    final anyValue = attribute.value;
+
+    if (T == String && anyValue is AnyValueString) {
+      return anyValue.value as T;
     }
+    if (T == bool && anyValue is AnyValueBool) {
+      return anyValue.value as T;
+    }
+    if (T == int && anyValue is AnyValueInt) {
+      return anyValue.value as T;
+    }
+    if (T == double && anyValue is AnyValueDouble) {
+      return anyValue.value as T;
+    }
+
+    if (anyValue is AnyValueArray) {
+      if (anyValue.value.every((e) => e is AnyValueString)) {
+        final result = anyValue.value.map((e) => e.value as String).toList();
+        if (result is T) return result as T;
+      }
+      if (anyValue.value.every((e) => e is AnyValueBool)) {
+        final result = anyValue.value.map((e) => e.value as bool).toList();
+        if (result is T) return result as T;
+      }
+      if (anyValue.value.every((e) => e is AnyValueInt)) {
+        final result = anyValue.value.map((e) => e.value as int).toList();
+        if (result is T) return result as T;
+      }
+      if (anyValue.value.every((e) => e is AnyValueDouble)) {
+        final result = anyValue.value.map((e) => e.value as double).toList();
+        if (result is T) return result as T;
+      }
+    }
+
+    throw StateError('Value for key "$key" is not of type $T');
   }
 
   /// Creates a new Attributes instance with a String attribute added or updated.
@@ -165,7 +152,7 @@ class Attributes {
   Attributes copyWithStringAttribute(String name, String value) {
     return AttributesCreate.create([
       ..._entries.values,
-      AttributeCreate.create<String>(name, value),
+      AttributeCreate.create(name, AnyValueString(value)),
     ]);
   }
 
@@ -177,7 +164,7 @@ class Attributes {
   Attributes copyWithBoolAttribute(String name, bool value) {
     return AttributesCreate.create([
       ..._entries.values,
-      AttributeCreate.create<bool>(name, value),
+      AttributeCreate.create(name, AnyValueBool(value)),
     ]);
   }
 
@@ -189,7 +176,7 @@ class Attributes {
   Attributes copyWithIntAttribute(String name, int value) {
     return AttributesCreate.create([
       ..._entries.values,
-      AttributeCreate.create<int>(name, value),
+      AttributeCreate.create(name, AnyValueInt(value)),
     ]);
   }
 
@@ -201,7 +188,7 @@ class Attributes {
   Attributes copyWithDoubleAttribute(String name, double value) {
     return AttributesCreate.create([
       ..._entries.values,
-      AttributeCreate.create<double>(name, value),
+      AttributeCreate.create(name, AnyValueDouble(value)),
     ]);
   }
 
@@ -213,7 +200,8 @@ class Attributes {
   Attributes copyWithStringListAttribute(String name, List<String> value) {
     return AttributesCreate.create([
       ..._entries.values,
-      AttributeCreate.create<List<String>>(name, value),
+      AttributeCreate.create(
+          name, AnyValueArray(value.map(AnyValueString.new).toList())),
     ]);
   }
 
@@ -225,7 +213,8 @@ class Attributes {
   Attributes copyWithBoolListAttribute(String name, List<bool> value) {
     return AttributesCreate.create([
       ..._entries.values,
-      AttributeCreate.create<List<bool>>(name, value),
+      AttributeCreate.create(
+          name, AnyValueArray(value.map(AnyValueBool.new).toList())),
     ]);
   }
 
@@ -237,7 +226,8 @@ class Attributes {
   Attributes copyWithIntListAttribute(String name, List<int> value) {
     return AttributesCreate.create([
       ..._entries.values,
-      AttributeCreate.create<List<int>>(name, value),
+      AttributeCreate.create(
+          name, AnyValueArray(value.map(AnyValueInt.new).toList())),
     ]);
   }
 
@@ -249,7 +239,8 @@ class Attributes {
   Attributes copyWithDoubleListAttribute(String name, List<double> value) {
     return AttributesCreate.create([
       ..._entries.values,
-      AttributeCreate.create<List<double>>(name, value),
+      AttributeCreate.create(
+          name, AnyValueArray(value.map(AnyValueDouble.new).toList())),
     ]);
   }
 
@@ -302,7 +293,7 @@ class Attributes {
   Map<String, dynamic> toJson() {
     final result = <String, dynamic>{};
     for (final entry in _entries.entries) {
-      result[entry.key] = entry.value.value;
+      result[entry.key] = entry.value.value.unwrap();
     }
     return result;
   }
@@ -324,7 +315,6 @@ class Attributes {
 /// Extension to create Attributes from a simple Map
 extension AttributesExtension on Map<String, Object> {
   /// Convert this map to Attributes
-  /// Empty string are not allowed and are skipped
   Attributes toAttributes() {
     return OTelFactory.getOrCreateDefault().attributesFromMap(this);
   }

--- a/lib/src/api/factory/otel_api_factory.dart
+++ b/lib/src/api/factory/otel_api_factory.dart
@@ -7,10 +7,11 @@ import '../../factory/otel_factory.dart';
 import '../../util/otel_error_handler.dart';
 import '../baggage/baggage.dart';
 import '../baggage/baggage_entry.dart';
+import '../common/any_value.dart';
 import '../common/attribute.dart';
 import '../common/attributes.dart';
 import '../common/instrumentation_scope.dart';
-import '../common/timestamp.dart';
+
 import '../context/context.dart';
 import '../context/context_key.dart';
 import '../id/id_generator.dart';
@@ -158,112 +159,89 @@ class OTelAPIFactory extends OTelFactory {
     return attrsFromMap(namedMap);
   }
 
-  /// Creates Attributes from a map of string keys to arbitrary values.
-  ///
-  /// This method handles converting various value types to appropriate attribute values:
-  /// - String values become string attributes (empty strings are ignored)
-  /// - int, double, and bool values become their respective attribute types
-  /// - DateTime values are converted to ISO8601 string attributes
-  /// - Attribute values are passed through directly
-  /// - Lists of strings, booleans, integers, or doubles become list attributes
-  /// - Other values are converted to strings using toString()
   static Attributes attrsFromMap(Map<String, Object> namedMap) {
     final attributes = <Attribute>[];
     namedMap.forEach((key, value) {
-      if (value is String) {
-        if (value.isNotEmpty) {
-          attributes.add(AttributeCreate.create<String>(key, value));
-        }
-      } else if (value is int) {
-        attributes.add(AttributeCreate.create<int>(key, value));
-      } else if (value is double) {
-        attributes.add(AttributeCreate.create<double>(key, value));
-      } else if (value is bool) {
-        attributes.add(AttributeCreate.create<bool>(key, value));
-      } else if (value is DateTime) {
-        final isoTimestamp = Timestamp.dateTimeToString(value);
-        attributes.add(AttributeCreate.create<String>(key, isoTimestamp));
-      } else if (value is Attribute) {
+      if (value is Attribute) {
         attributes.add(value);
-      } else if (value is List) {
-        // Element-check rather than hard-cast: the static list type is
-        // often List<Object> or List<dynamic> (e.g. from map literals),
-        // which `as List<String>` would reject at runtime.
-        if (value.isNotEmpty) {
-          if (value.every((e) => e is String)) {
-            attributes.add(AttributeCreate.create<List<String>>(
-                key, value.cast<String>()));
-          } else if (value.every((e) => e is bool)) {
-            attributes.add(
-                AttributeCreate.create<List<bool>>(key, value.cast<bool>()));
-          } else if (value.every((e) => e is int)) {
-            attributes
-                .add(AttributeCreate.create<List<int>>(key, value.cast<int>()));
-          } else if (value.every((e) => e is double || e is int)) {
-            // Mixed numeric lists are promoted to double.
-            attributes.add(AttributeCreate.create<List<double>>(
-                key,
-                value
-                    .map((e) => e is int ? e.toDouble() : e as double)
-                    .toList()));
-          } else {
-            OTelErrorHandling.report(ArgumentError(
-                'Ignoring attribute $key because the list contains unsupported types. Only String, bool, int, double lists are allowed by the OTel specification.'));
-          }
-        }
       } else {
-        attributes.add(AttributeCreate.create<String>(key, '$value'));
+        try {
+          attributes
+              .add(AttributeCreate.create(key, AnyValue.fromObject(value)));
+        } catch (e) {
+          OTelErrorHandling.report(ArgumentError(
+              'Ignoring attribute "$key" because it contains unsupported types: $e'));
+        }
       }
     });
     return AttributesCreate.create(attributes);
   }
 
-  /// Creates an `AttributeValue` for the given String.
+  /// Creates an `Attribute` for the given String.
   @override
-  Attribute<String> attributeString(String key, String value) {
-    return AttributeCreate.create(key, value);
+  Attribute attributeString(String key, String value) {
+    return AttributeCreate.create(key, AnyValueString(value));
   }
 
-  /// Creates an `AttributeValue` for the given boolean.
+  /// Creates an `Attribute` for the given boolean.
   @override
-  Attribute<bool> attributeBool(String key, bool value) {
-    return AttributeCreate.create(key, value);
+  Attribute attributeBool(String key, bool value) {
+    return AttributeCreate.create(key, AnyValueBool(value));
   }
 
-  /// Creates an `AttributeValue` for the given int.
+  /// Creates an `Attribute` for the given int.
   @override
-  Attribute<int> attributeInt(String key, int value) {
-    return AttributeCreate.create(key, value);
+  Attribute attributeInt(String key, int value) {
+    return AttributeCreate.create(key, AnyValueInt(value));
   }
 
-  /// Creates an `AttributeValue` for the given double.
+  /// Creates an `Attribute` for the given double.
   @override
-  Attribute<double> attributeDouble(String key, double value) {
-    return AttributeCreate.create(key, value);
+  Attribute attributeDouble(String key, double value) {
+    return AttributeCreate.create(key, AnyValueDouble(value));
   }
 
-  /// Creates an `AttributeValue` for the given String.
+  /// Creates an `Attribute` for the given String list.
   @override
-  Attribute<List<String>> attributeStringList(String key, List<String> value) {
-    return AttributeCreate.create(key, value);
+  Attribute attributeStringList(String key, List<String> value) {
+    return AttributeCreate.create(
+        key, AnyValueArray(value.map(AnyValueString.new).toList()));
   }
 
-  /// Creates an `AttributeValue` for the given boolean.
+  /// Creates an `Attribute` for the given boolean list.
   @override
-  Attribute<List<bool>> attributeBoolList(String key, List<bool> value) {
-    return AttributeCreate.create(key, value);
+  Attribute attributeBoolList(String key, List<bool> value) {
+    return AttributeCreate.create(
+        key, AnyValueArray(value.map(AnyValueBool.new).toList()));
   }
 
-  /// Creates an `AttributeValue` for the given int.
+  /// Creates an `Attribute` for the given int list.
   @override
-  Attribute<List<int>> attributeIntList(String key, List<int> value) {
-    return AttributeCreate.create(key, value);
+  Attribute attributeIntList(String key, List<int> value) {
+    return AttributeCreate.create(
+        key, AnyValueArray(value.map(AnyValueInt.new).toList()));
   }
 
-  /// Creates an `AttributeValue` for the given double.
+  /// Creates an `Attribute` for the given double list.
   @override
-  Attribute<List<double>> attributeDoubleList(String key, List<double> value) {
-    return AttributeCreate.create(key, value);
+  Attribute attributeDoubleList(String key, List<double> value) {
+    return AttributeCreate.create(
+        key, AnyValueArray(value.map(AnyValueDouble.new).toList()));
+  }
+
+  @override
+  Attribute attributeMap(String key, Map<String, AnyValue> value) {
+    return AttributeCreate.create(key, AnyValueMap(value));
+  }
+
+  @override
+  Attribute attributeArray(String key, List<AnyValue> value) {
+    return AttributeCreate.create(key, AnyValueArray(value));
+  }
+
+  @override
+  Attribute attributeBytes(String key, List<int> value) {
+    return AttributeCreate.create(key, AnyValueBytes(value));
   }
 
   @override

--- a/lib/src/api/logs/log_record.dart
+++ b/lib/src/api/logs/log_record.dart
@@ -3,6 +3,7 @@
 
 import 'package:fixnum/fixnum.dart';
 
+import '../common/any_value.dart';
 import '../common/attributes.dart';
 import '../context/context.dart';
 import 'severity.dart';
@@ -31,7 +32,7 @@ abstract class LogRecord {
 
   String? get severityText;
 
-  dynamic get body;
+  AnyValue? get body;
 
   Attributes? get attributes;
 

--- a/lib/src/api/logs/logger.dart
+++ b/lib/src/api/logs/logger.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import 'package:meta/meta.dart';
+import '../common/any_value.dart';
 import '../common/attributes.dart';
 import '../context/context.dart';
 import 'severity.dart';
@@ -61,7 +62,7 @@ class APILogger {
     Context? context,
     Severity? severityNumber,
     String? severityText,
-    dynamic body,
+    AnyValue? body,
     Attributes? attributes,
     String? eventName,
   }) {

--- a/lib/src/api/otel_api.dart
+++ b/lib/src/api/otel_api.dart
@@ -9,6 +9,7 @@ import '../util/otel_error_handler.dart';
 import '../util/otel_log.dart';
 import 'baggage/baggage.dart';
 import 'baggage/baggage_entry.dart';
+import 'common/any_value.dart';
 import 'common/attribute.dart';
 import 'common/attributes.dart';
 import 'common/instrumentation_scope.dart';
@@ -440,54 +441,69 @@ class OTelAPI {
   }
 
   /// Create a string attribute key
-  static Attribute<String> attributeString(String name, String value) {
+  static Attribute attributeString(String name, String value) {
     _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.attributeString(name, value);
   }
 
   /// Create a boolean attribute key
-  static Attribute<bool> attributeBool(String name, bool value) {
+  static Attribute attributeBool(String name, bool value) {
     _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.attributeBool(name, value);
   }
 
   /// Create an integer attribute key
-  static Attribute<int> attributeInt(String name, int value) {
+  static Attribute attributeInt(String name, int value) {
     _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.attributeInt(name, value);
   }
 
   /// Create a double attribute key
-  static Attribute<double> attributeDouble(String name, double value) {
+  static Attribute attributeDouble(String name, double value) {
     _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.attributeDouble(name, value);
   }
 
   /// Create a string list attribute key
-  static Attribute<List<String>> attributeStringList(
-      String name, List<String> value) {
+  static Attribute attributeStringList(String name, List<String> value) {
     _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.attributeStringList(name, value);
   }
 
   /// Create a boolean list attribute key
-  static Attribute<List<bool>> attributeBoolList(
-      String name, List<bool> value) {
+  static Attribute attributeBoolList(String name, List<bool> value) {
     _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.attributeBoolList(name, value);
   }
 
   /// Create an integer list attribute key
-  static Attribute<List<int>> attributeIntList(String name, List<int> value) {
+  static Attribute attributeIntList(String name, List<int> value) {
     _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.attributeIntList(name, value);
   }
 
   /// Create a double list attribute key
-  static Attribute<List<double>> attributeDoubleList(
-      String name, List<double> value) {
+  static Attribute attributeDoubleList(String name, List<double> value) {
     _getAndCacheOtelFactory();
     return OTelFactory.otelFactory!.attributeDoubleList(name, value);
+  }
+
+  /// Create a map attribute key
+  static Attribute attributeMap(String name, Map<String, AnyValue> value) {
+    _getAndCacheOtelFactory();
+    return OTelFactory.otelFactory!.attributeMap(name, value);
+  }
+
+  /// Create an array attribute key
+  static Attribute attributeArray(String name, List<AnyValue> value) {
+    _getAndCacheOtelFactory();
+    return OTelFactory.otelFactory!.attributeArray(name, value);
+  }
+
+  /// Create a bytes attribute key
+  static Attribute attributeBytes(String name, List<int> value) {
+    _getAndCacheOtelFactory();
+    return OTelFactory.otelFactory!.attributeBytes(name, value);
   }
 
   /// Creates an `Attributes` collection from a list of [Attribute]s.

--- a/lib/src/factory/otel_factory.dart
+++ b/lib/src/factory/otel_factory.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import '../api/baggage/baggage.dart';
 import '../api/baggage/baggage_entry.dart';
+import '../api/common/any_value.dart';
 import '../api/common/attribute.dart';
 import '../api/common/attributes.dart';
 import '../api/common/instrumentation_scope.dart';
@@ -358,29 +359,38 @@ abstract class OTelFactory {
   /// are converted into `BaggageEntry`s without metadata.
   Baggage baggageForMap(Map<String, String> keyValuePairs);
 
-  /// Creates an `AttributeValue` for the given String.
-  Attribute<String> attributeString(String key, String value);
+  /// Creates an `Attribute` for the given String.
+  Attribute attributeString(String key, String value);
 
-  /// Creates an `AttributeValue` for the given boolean.
-  Attribute<bool> attributeBool(String key, bool value);
+  /// Creates an `Attribute` for the given boolean.
+  Attribute attributeBool(String key, bool value);
 
-  /// Creates an `AttributeValue` for the given int.
-  Attribute<int> attributeInt(String key, int value);
+  /// Creates an `Attribute` for the given int.
+  Attribute attributeInt(String key, int value);
 
-  /// Creates an `AttributeValue` for the given double.
-  Attribute<double> attributeDouble(String key, double value);
+  /// Creates an `Attribute` for the given double.
+  Attribute attributeDouble(String key, double value);
 
-  /// Creates an `AttributeValue` for the given String.
-  Attribute<List<String>> attributeStringList(String key, List<String> value);
+  /// Creates an `Attribute` for the given String.
+  Attribute attributeStringList(String key, List<String> value);
 
-  /// Creates an `AttributeValue` for the given boolean.
-  Attribute<List<bool>> attributeBoolList(String key, List<bool> value);
+  /// Creates an `Attribute` for the given boolean.
+  Attribute attributeBoolList(String key, List<bool> value);
 
-  /// Creates an `AttributeValue` for the given int.
-  Attribute<List<int>> attributeIntList(String key, List<int> value);
+  /// Creates an `Attribute` for the given int.
+  Attribute attributeIntList(String key, List<int> value);
 
-  /// Creates an `AttributeValue` for the given double.
-  Attribute<List<double>> attributeDoubleList(String key, List<double> value);
+  /// Creates an `Attribute` for the given double.
+  Attribute attributeDoubleList(String key, List<double> value);
+
+  /// Creates an `Attribute` for the given map of string to AnyValue.
+  Attribute attributeMap(String key, Map<String, AnyValue> value);
+
+  /// Creates an `Attribute` for the given list of AnyValue.
+  Attribute attributeArray(String key, List<AnyValue> value);
+
+  /// Creates an `Attribute` for the given byte array.
+  Attribute attributeBytes(String key, List<int> value);
 
   /// Creates an `Attributes` collection.
   Attributes attributes([List<Attribute>? entries]);

--- a/test/unit/api/common/attribute_test.dart
+++ b/test/unit/api/common/attribute_test.dart
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+import 'package:dartastic_opentelemetry_api/src/api/common/any_value.dart';
 import 'package:dartastic_opentelemetry_api/src/api/otel_api.dart';
 import 'package:test/test.dart';
 
@@ -13,6 +14,54 @@ void main() {
         serviceName: 'test-service',
         serviceVersion: '1.0.0',
       );
+    });
+
+    group('AnyValue tests', () {
+      test('unwrap handles all AnyValue types', () {
+        expect(AnyValue.empty().unwrap(), isNull);
+        expect(AnyValue.fromString('test').unwrap(), equals('test'));
+        expect(AnyValue.fromBool(true).unwrap(), equals(true));
+        expect(AnyValue.fromInt(42).unwrap(), equals(42));
+        expect(AnyValue.fromDouble(3.14).unwrap(), equals(3.14));
+        expect(AnyValue.fromList([AnyValue.fromString('x')]).unwrap(),
+            equals(['x']));
+        expect(AnyValue.fromMap({'k': AnyValue.fromInt(1)}).unwrap(),
+            equals({'k': 1}));
+        expect(AnyValue.fromBytes([0, 1]).unwrap(), equals([0, 1]));
+      });
+
+      test('toJson is implemented', () {
+        final anyVal = AnyValue.fromMap({'k': AnyValue.fromInt(1)});
+        expect(anyVal.toJson(), equals({'k': 1}));
+      });
+
+      test('fromObject throws on invalid map key', () {
+        expect(() => AnyValue.fromObject({1: 'val'}),
+            throwsA(isA<ArgumentError>()));
+      });
+
+      test('equality and hashCode', () {
+        final nullVal1 = AnyValue.empty();
+        final nullVal2 = AnyValue.fromObject(null);
+        expect(nullVal1, equals(nullVal2));
+        expect(nullVal1.hashCode, equals(nullVal2.hashCode));
+        expect(nullVal1.value, isNull);
+
+        final mapVal1 = AnyValue.fromMap({'a': AnyValue.fromInt(1)});
+        final mapVal2 = AnyValue.fromObject({'a': 1});
+        expect(mapVal1, equals(mapVal2));
+        expect(mapVal1.hashCode, equals(mapVal2.hashCode));
+
+        final bytesVal1 = AnyValue.fromBytes([1, 2]);
+        final bytesVal2 = AnyValue.fromBytes([1, 2]);
+        expect(bytesVal1, equals(bytesVal2));
+        expect(bytesVal1.hashCode, equals(bytesVal2.hashCode));
+
+        final arrayVal1 = AnyValue.fromList([AnyValue.fromInt(1)]);
+        final arrayVal2 = AnyValue.fromObject([1]);
+        expect(arrayVal1, equals(arrayVal2));
+        expect(arrayVal1.hashCode, equals(arrayVal2.hashCode));
+      });
     });
 
     group('equality', () {
@@ -66,23 +115,16 @@ void main() {
         expect(doubleList.hashCode, isNot(equals(doubleList2.hashCode)));
       });
 
-      test('empty collections throw ArgumentError', () {
-        expect(
-          () => OTelAPI.attributeStringList('foo', []),
-          throwsArgumentError,
-        );
-        expect(
-          () => OTelAPI.attributeIntList('foo', []),
-          throwsArgumentError,
-        );
-        expect(
-          () => OTelAPI.attributeBoolList('foo', []),
-          throwsArgumentError,
-        );
-        expect(
-          () => OTelAPI.attributeDoubleList('foo', []),
-          throwsArgumentError,
-        );
+      test('empty collections are valid', () {
+        final stringList = OTelAPI.attributeStringList('foo', []);
+        final intList = OTelAPI.attributeIntList('foo', []);
+        final boolList = OTelAPI.attributeBoolList('foo', []);
+        final doubleList = OTelAPI.attributeDoubleList('foo', []);
+
+        expect((stringList.value as AnyValueArray).value, isEmpty);
+        expect((intList.value as AnyValueArray).value, isEmpty);
+        expect((boolList.value as AnyValueArray).value, isEmpty);
+        expect((doubleList.value as AnyValueArray).value, isEmpty);
       });
     });
   });

--- a/test/unit/api/common/attribute_validation_test.dart
+++ b/test/unit/api/common/attribute_validation_test.dart
@@ -18,15 +18,6 @@ void main() {
       );
     });
 
-    test('empty string value throws', () {
-      expect(() => OTelAPI.attributeString('k', ''), throwsArgumentError);
-    });
-
-    test('empty list value throws', () {
-      expect(() => OTelAPI.attributeStringList('k', <String>[]),
-          throwsArgumentError);
-    });
-
     test('toString includes the value', () {
       expect(OTelAPI.attributeString('k', 'v').toString(),
           equals('AttributeValue(v)'));
@@ -46,11 +37,12 @@ void main() {
       expect(attrs.getIntList('counts'), equals([1, 2, 3]));
     });
 
-    test('Attributes.of converts mixed numeric lists to double', () {
+    test('Attributes.of ignores mixed numeric lists without coercion', () {
       final attrs = Attributes.of({
         'nums': <Object>[1, 2.5]
       });
-      expect(attrs.getDoubleList('nums'), equals([1.0, 2.5]));
+      // The array has mixed types (int and double). getDoubleList will throw StateError.
+      expect(() => attrs.getDoubleList('nums'), throwsA(isA<StateError>()));
     });
 
     test('Attributes.of ignores lists of unsupported types', () {
@@ -69,12 +61,10 @@ void main() {
         'names': <dynamic>['a', 'b'],
         'flags': <dynamic>[true, false],
         'counts': <dynamic>[1, 2],
-        'nums': <dynamic>[1, 2.5],
       });
       expect(attrs.getStringList('names'), equals(['a', 'b']));
       expect(attrs.getBoolList('flags'), equals([true, false]));
       expect(attrs.getIntList('counts'), equals([1, 2]));
-      expect(attrs.getDoubleList('nums'), equals([1.0, 2.5]));
     });
   });
 }

--- a/test/unit/api/common/attributes_test.dart
+++ b/test/unit/api/common/attributes_test.dart
@@ -24,7 +24,7 @@ void main() {
       attributes = attributes.copyWithStringAttribute(name, value);
 
       expect(attributes.getString(name), equals(value));
-      expect(attributes.toMap()[name]!.value, equals(value));
+      expect(attributes.toMap()[name]!.value.value, equals(value));
     });
 
     test('should store and retrieve bool attributes', () {
@@ -33,7 +33,7 @@ void main() {
       attributes = attributes.copyWithBoolAttribute(name, value);
 
       expect(attributes.getBool(name), equals(value));
-      expect(attributes.toMap()[name]!.value, equals(value));
+      expect(attributes.toMap()[name]!.value.value, equals(value));
     });
 
     test('should store and retrieve int attributes', () {
@@ -42,7 +42,7 @@ void main() {
       attributes = attributes.copyWithIntAttribute(name, value);
 
       expect(attributes.getInt(name), equals(value));
-      expect(attributes.toMap()[name]!.value, equals(value));
+      expect(attributes.toMap()[name]!.value.value, equals(value));
     });
 
     test('should store and retrieve double attributes', () {
@@ -51,7 +51,7 @@ void main() {
       attributes = attributes.copyWithDoubleAttribute(name, value);
 
       expect(attributes.getDouble(name), equals(value));
-      expect(attributes.toMap()[name]!.value, equals(value));
+      expect(attributes.toMap()[name]!.value.value, equals(value));
     });
 
     test('should store and retrieve string list attributes', () {
@@ -60,7 +60,12 @@ void main() {
       attributes = attributes.copyWithStringListAttribute(name, value);
 
       expect(attributes.getStringList(name), equals(value));
-      expect(attributes.toMap()[name]!.value, equals(value));
+      expect(
+          (attributes.toMap()[name]!.value as AnyValueArray)
+              .value
+              .map((e) => e.value as String)
+              .toList(),
+          equals(value));
     });
 
     test('should store and retrieve bool list attributes', () {
@@ -69,7 +74,12 @@ void main() {
       attributes = attributes.copyWithBoolListAttribute(name, value);
 
       expect(attributes.getBoolList(name), equals(value));
-      expect(attributes.toMap()[name]!.value, equals(value));
+      expect(
+          (attributes.toMap()[name]!.value as AnyValueArray)
+              .value
+              .map((e) => e.value as bool)
+              .toList(),
+          equals(value));
     });
 
     test('should store and retrieve int list attributes', () {
@@ -78,7 +88,12 @@ void main() {
       attributes = attributes.copyWithIntListAttribute(name, value);
 
       expect(attributes.getIntList(name), equals(value));
-      expect(attributes.toMap()[name]!.value, equals(value));
+      expect(
+          (attributes.toMap()[name]!.value as AnyValueArray)
+              .value
+              .map((e) => e.value as int)
+              .toList(),
+          equals(value));
     });
 
     test('should store and retrieve double list attributes', () {
@@ -87,16 +102,26 @@ void main() {
       attributes = attributes.copyWithDoubleListAttribute(name, value);
 
       expect(attributes.getDoubleList(name), equals(value));
-      expect(attributes.toMap()[name]!.value, equals(value));
+      expect(
+          (attributes.toMap()[name]!.value as AnyValueArray)
+              .value
+              .map((e) => e.value as double)
+              .toList(),
+          equals(value));
     });
 
-    test('should store and retrieve string list attributes', () {
-      final name = 'test.key';
-      final value = ['test-value', 'foo', 'bar'];
+    test('should store and retrieve string list attributes 2', () {
+      final name = 'test.key2';
+      final value = ['test-value2', 'foo2', 'bar2'];
       attributes = attributes.copyWithStringListAttribute(name, value);
 
       expect(attributes.getStringList(name), equals(value));
-      expect(attributes.toMap()[name]!.value, equals(value));
+      expect(
+          (attributes.toMap()[name]!.value as AnyValueArray)
+              .value
+              .map((e) => e.value as String)
+              .toList(),
+          equals(value));
     });
 
     test('should store and retrieve attributes', () {
@@ -149,20 +174,20 @@ void main() {
           .copyWithAttributes(OTelAPI.attributesFromList(attributeList));
 
       expect(attributes.getString(stringAttribute.key),
-          equals(stringAttribute.value));
-      expect(attributes.getInt(intAttribute.key), equals(intAttribute.value));
-      expect(
-          attributes.getBool(boolAttribute.key), equals(boolAttribute.value));
+          equals(stringAttribute.value.value));
+      expect(attributes.getInt(intAttribute.key),
+          equals(intAttribute.value.value));
+      expect(attributes.getBool(boolAttribute.key),
+          equals(boolAttribute.value.value));
       expect(attributes.getDouble(doubleAttribute.key),
-          equals(doubleAttribute.value));
+          equals(doubleAttribute.value.value));
       expect(attributes.getStringList(stringListAttribute.key),
-          equals(stringListAttribute.value));
+          equals(['a', 'b', 'c']));
       expect(attributes.getBoolList(boolListAttribute.key),
-          equals(boolListAttribute.value));
-      expect(attributes.getIntList(intListAttribute.key),
-          equals(intListAttribute.value));
+          equals([true, false, true]));
+      expect(attributes.getIntList(intListAttribute.key), equals([1, 2, 3]));
       expect(attributes.getDoubleList(doubleListAttribute.key),
-          equals(doubleListAttribute.value));
+          equals([0.0, 1.1, 22.22]));
     });
 
     test('should convert from Map<String, Object>', () {
@@ -177,12 +202,22 @@ void main() {
 
       final attrs = map.toAttributes();
       final attrAsMap = attrs.toMap();
-      expect(attrAsMap['string.key']!.value, equals('string-value'));
-      expect(attrAsMap['int.key']!.value, equals(42));
-      expect(attrAsMap['bool.key']!.value, equals(true));
-      expect(attrAsMap['double.key']!.value, equals(42.5));
-      expect(attrAsMap['string.list']!.value, equals(['a', 'b', 'c']));
-      expect(attrAsMap['int.list']!.value, equals([1, 2, 3]));
+      expect(attrAsMap['string.key']!.value.value, equals('string-value'));
+      expect(attrAsMap['int.key']!.value.value, equals(42));
+      expect(attrAsMap['bool.key']!.value.value, equals(true));
+      expect(attrAsMap['double.key']!.value.value, equals(42.5));
+      expect(
+          (attrAsMap['string.list']!.value as AnyValueArray)
+              .value
+              .map((e) => e.value as String)
+              .toList(),
+          equals(['a', 'b', 'c']));
+      expect(
+          (attrAsMap['int.list']!.value as AnyValueArray)
+              .value
+              .map((e) => e.value as int)
+              .toList(),
+          equals([1, 2, 3]));
     });
 
     test('should convert from Map<String, Object> with an Attribute value', () {
@@ -195,14 +230,24 @@ void main() {
       expect(attrs.getInt('long-winded-int'), equals(3333));
     });
 
-    test(
-        'should convert from Map<String, Object> with an Object to string value',
+    test('should convert from Map<String, Object> with DateTime to ISO string',
         () {
+      final now = DateTime.utc(2023, 1, 1, 12, 0, 0);
       final attrs = OTelAPI.attributesFromMap({
-        'net.type': NetworkConnectionType
-            .wifi, //don't put a key as a value, this just tests toString
+        'ts': now,
       });
-      expect(attrs.getString('net.type'), equals('wifi'));
+      expect(attrs.getString('ts'), equals('2023-01-01T12:00:00.000Z'));
+    });
+
+    test('should ignore unsupported objects in Map<String, Object>', () {
+      final attrs = OTelAPI.attributesFromMap({
+        'net.type': NetworkConnectionType.wifi, // Unsupported enum
+        'valid': 123,
+      });
+      // net.type is ignored, only valid is kept
+      expect(attrs.getString('net.type'), isNull);
+      expect(attrs.getInt('valid'), equals(123));
+      expect(attrs.length, equals(1));
     });
 
     test('remove returns new Attributes without given key', () {
@@ -472,24 +517,25 @@ void main() {
       expect(attrs.getIntList('key'), equals([1, 2, 3]));
     });
 
-    test('fromJson converts mixed int/double list to double list', () {
+    test('fromJson ignores mixed int/double list', () {
       final json = <String, dynamic>{
         'key': [1, 2.5, 3]
       };
       final attrs = Attributes.fromJson(json);
 
-      expect(attrs.getDoubleList('key'), equals([1.0, 2.5, 3.0]));
+      expect(() => attrs.getDoubleList('key'), throwsA(isA<StateError>()));
     });
 
-    test('fromJson ignores empty list with warning', () {
+    test('fromJson accepts empty list', () {
       final json = <String, dynamic>{'key': <dynamic>[]};
       final attrs = Attributes.fromJson(json);
 
-      // Empty lists are ignored per OTel spec
-      expect(attrs.isEmpty, isTrue);
+      // Empty lists are valid per OTel spec
+      expect(attrs.isEmpty, isFalse);
+      expect((attrs.toMap()['key']!.value as AnyValueArray).value, isEmpty);
     });
 
-    test('fromJson ignores unsupported list types with warning', () {
+    test('fromJson parses list of Map values', () {
       final json = <String, dynamic>{
         'key': [
           {'nested': 'object'}
@@ -497,18 +543,27 @@ void main() {
       };
       final attrs = Attributes.fromJson(json);
 
-      // Unsupported types are ignored
-      expect(attrs.isEmpty, isTrue);
+      // List of Maps are valid per OTel spec (AnyValueArray of AnyValueMap)
+      expect(attrs.isEmpty, isFalse);
+      expect(
+          ((attrs.toMap()['key']!.value as AnyValueArray).value.first
+                  as AnyValueMap)
+              .value
+              .keys
+              .first,
+          equals('nested'));
     });
 
-    test('fromJson ignores unsupported value types with warning', () {
+    test('fromJson parses Map values', () {
       final json = <String, dynamic>{
         'key': {'nested': 'object'}
       };
       final attrs = Attributes.fromJson(json);
 
-      // Unsupported types are ignored
-      expect(attrs.isEmpty, isTrue);
+      // Maps are valid per OTel spec (AnyValueMap)
+      expect(attrs.isEmpty, isFalse);
+      expect((attrs.toMap()['key']!.value as AnyValueMap).value.keys.first,
+          equals('nested'));
     });
   });
 

--- a/test/unit/api/error_report_routing_test.dart
+++ b/test/unit/api/error_report_routing_test.dart
@@ -43,9 +43,7 @@ void main() {
     test('a dropped attribute (unsupported value type) is reported', () {
       // Attributes.of stringifies unknown scalar types by design; fromJson
       // drops them — the drop must reach the handler.
-      final attrs = Attributes.fromJson({
-        'unsupported': {'nested': 'map'}
-      });
+      final attrs = Attributes.fromJson({'unsupported': () {}});
 
       expect(attrs.toList(), isEmpty, reason: 'the attribute is dropped');
       expect(reported, hasLength(1));
@@ -57,7 +55,7 @@ void main() {
 
     test('a dropped attribute (unsupported list element type) is reported', () {
       final attrs = Attributes.of({
-        'mixed': [1, 'two']
+        'mixed': [1, () {}]
       });
 
       expect(attrs.toList(), isEmpty, reason: 'the attribute is dropped');

--- a/test/unit/api/factory/otel_api_factory_test.dart
+++ b/test/unit/api/factory/otel_api_factory_test.dart
@@ -207,52 +207,72 @@ void main() {
     test('creates attribute with string value', () {
       final attribute = factory.attributeString('string-key', 'string-value');
       expect(attribute.key, equals('string-key'));
-      expect(attribute.value, equals('string-value'));
+      expect(attribute.value.unwrap(), equals('string-value'));
     });
 
     test('creates attribute with boolean value', () {
       final attribute = factory.attributeBool('bool-key', true);
       expect(attribute.key, equals('bool-key'));
-      expect(attribute.value, equals(true));
+      expect(attribute.value.unwrap(), equals(true));
     });
 
     test('creates attribute with integer value', () {
       final attribute = factory.attributeInt('int-key', 42);
       expect(attribute.key, equals('int-key'));
-      expect(attribute.value, equals(42));
+      expect(attribute.value.unwrap(), equals(42));
     });
 
     test('creates attribute with double value', () {
       final attribute = factory.attributeDouble('double-key', 3.14);
       expect(attribute.key, equals('double-key'));
-      expect(attribute.value, equals(3.14));
+      expect(attribute.value.unwrap(), equals(3.14));
     });
 
     test('creates attribute with string list value', () {
       final attribute =
           factory.attributeStringList('string-list-key', ['value1', 'value2']);
       expect(attribute.key, equals('string-list-key'));
-      expect(attribute.value, equals(['value1', 'value2']));
+      expect(attribute.value.unwrap(), equals(['value1', 'value2']));
     });
 
     test('creates attribute with boolean list value', () {
       final attribute =
           factory.attributeBoolList('bool-list-key', [true, false]);
       expect(attribute.key, equals('bool-list-key'));
-      expect(attribute.value, equals([true, false]));
+      expect(attribute.value.unwrap(), equals([true, false]));
     });
 
     test('creates attribute with integer list value', () {
       final attribute = factory.attributeIntList('int-list-key', [1, 2, 3]);
       expect(attribute.key, equals('int-list-key'));
-      expect(attribute.value, equals([1, 2, 3]));
+      expect(attribute.value.unwrap(), equals([1, 2, 3]));
+    });
+
+    test('creates attribute with map value', () {
+      final attribute =
+          factory.attributeMap('map-key', {'k': AnyValue.fromObject('v')});
+      expect(attribute.key, equals('map-key'));
+      expect((attribute.value.unwrap() as Map)['k'], equals('v'));
+    });
+
+    test('creates attribute with array value', () {
+      final attribute =
+          factory.attributeArray('arr-key', [AnyValue.fromObject('v')]);
+      expect(attribute.key, equals('arr-key'));
+      expect((attribute.value.unwrap() as List)[0], equals('v'));
+    });
+
+    test('creates attribute with bytes value', () {
+      final attribute = factory.attributeBytes('bytes-key', [0, 255]);
+      expect(attribute.key, equals('bytes-key'));
+      expect(attribute.value.unwrap(), equals([0, 255]));
     });
 
     test('creates attribute with double list value', () {
       final attribute =
           factory.attributeDoubleList('double-list-key', [1.1, 2.2, 3.3]);
       expect(attribute.key, equals('double-list-key'));
-      expect(attribute.value, equals([1.1, 2.2, 3.3]));
+      expect(attribute.value.unwrap(), equals([1.1, 2.2, 3.3]));
     });
 
     test('creates trace ID', () {

--- a/test/unit/api/logs/log_provider_test.dart
+++ b/test/unit/api/logs/log_provider_test.dart
@@ -55,9 +55,9 @@ void main() {
       );
 
       expect(logger, isNotNull);
-      expect(logger.attributes?.toMap()['library.name']?.value,
+      expect(logger.attributes?.toMap()['library.name']?.value.unwrap(),
           equals('test-lib'));
-      expect(logger.attributes?.toMap()['library.version']?.value,
+      expect(logger.attributes?.toMap()['library.version']?.value.unwrap(),
           equals('1.0.0'));
     });
 

--- a/test/unit/api/logs/logger_test.dart
+++ b/test/unit/api/logs/logger_test.dart
@@ -68,9 +68,9 @@ void main() {
 
       expect(logger, isNotNull);
       expect(logger.attributes, isNotNull);
-      expect(logger.attributes?.toMap()['library.name']?.value,
+      expect(logger.attributes?.toMap()['library.name']?.value.unwrap(),
           equals('test-logger'));
-      expect(logger.attributes?.toMap()['library.language']?.value,
+      expect(logger.attributes?.toMap()['library.language']?.value.unwrap(),
           equals('dart'));
     });
 
@@ -94,7 +94,8 @@ void main() {
       final provider = OTelAPI.loggerProvider();
       final logger = provider.getLogger('test-logger');
 
-      expect(() => logger.emit(body: 'test log message'), returnsNormally);
+      expect(() => logger.emit(body: AnyValue.fromObject('test log message')),
+          returnsNormally);
     });
 
     test('emit does not throw with severity', () {
@@ -177,7 +178,7 @@ void main() {
           context: context,
           severityNumber: Severity.WARN,
           severityText: 'WARN',
-          body: 'This is a warning message',
+          body: AnyValue.fromObject('This is a warning message'),
           attributes: attributes,
           eventName: 'test.warning.event',
         ),
@@ -190,19 +191,23 @@ void main() {
       final logger = provider.getLogger('test-logger');
 
       // String body
-      expect(() => logger.emit(body: 'string message'), returnsNormally);
+      expect(() => logger.emit(body: AnyValue.fromObject('string body')),
+          returnsNormally);
 
       // Number body
-      expect(() => logger.emit(body: 42), returnsNormally);
+      expect(() => logger.emit(body: AnyValue.fromObject(42)), returnsNormally);
 
       // Boolean body
-      expect(() => logger.emit(body: true), returnsNormally);
+      expect(
+          () => logger.emit(body: AnyValue.fromObject(true)), returnsNormally);
 
       // Map body
-      expect(() => logger.emit(body: {'key': 'value'}), returnsNormally);
+      expect(() => logger.emit(body: AnyValue.fromObject({'key': 'value'})),
+          returnsNormally);
 
       // List body
-      expect(() => logger.emit(body: ['item1', 'item2']), returnsNormally);
+      expect(() => logger.emit(body: AnyValue.fromObject(['item1', 'item2'])),
+          returnsNormally);
     });
 
     test('emit with different severity levels', () {
@@ -227,9 +232,15 @@ void main() {
 
       expect(
         () {
-          logger.emit(body: 'message 1', severityNumber: Severity.INFO);
-          logger.emit(body: 'message 2', severityNumber: Severity.WARN);
-          logger.emit(body: 'message 3', severityNumber: Severity.ERROR);
+          logger.emit(
+              body: AnyValue.fromObject('message 1'),
+              severityNumber: Severity.INFO);
+          logger.emit(
+              body: AnyValue.fromObject('message 2'),
+              severityNumber: Severity.WARN);
+          logger.emit(
+              body: AnyValue.fromObject('message 3'),
+              severityNumber: Severity.ERROR);
         },
         returnsNormally,
       );

--- a/test/unit/api/otel_api_test.dart
+++ b/test/unit/api/otel_api_test.dart
@@ -488,6 +488,24 @@ void main() {
       expect(messages.join('\n'),
           contains('replacing the installed no-op API factory'));
     });
+
+    test('creates attributeMap, attributeArray, attributeBytes', () {
+      final mapAttr =
+          OTelAPI.attributeMap('map-key', {'nested': AnyValue.fromObject(1)});
+      expect(mapAttr.key, equals('map-key'));
+      expect(
+          (mapAttr.value as AnyValueMap).value['nested']?.unwrap(), equals(1));
+
+      final arrAttr =
+          OTelAPI.attributeArray('arr-key', [AnyValue.fromObject('value')]);
+      expect(arrAttr.key, equals('arr-key'));
+      expect(
+          (arrAttr.value as AnyValueArray).value[0].unwrap(), equals('value'));
+
+      final bytesAttr = OTelAPI.attributeBytes('bytes-key', [0, 1, 2]);
+      expect(bytesAttr.key, equals('bytes-key'));
+      expect((bytesAttr.value as AnyValueBytes).value, equals([0, 1, 2]));
+    });
   });
 }
 

--- a/test/unit/api/trace/span_coverage_test.dart
+++ b/test/unit/api/trace/span_coverage_test.dart
@@ -161,11 +161,13 @@ void main() {
       expect(events, hasLength(1));
 
       final eventAttrs = events![0].attributes!.toMap();
-      expect(eventAttrs['exception.type']?.value, contains('Exception'));
-      expect(eventAttrs['exception.message']?.value, contains('Test error'));
-      expect(eventAttrs['exception.stacktrace']?.value, isNotNull);
-      expect(eventAttrs['exception.escaped']?.value, isTrue);
-      expect(eventAttrs['custom']?.value, equals('attribute'));
+      expect(
+          eventAttrs['exception.type']?.value.unwrap(), contains('Exception'));
+      expect(eventAttrs['exception.message']?.value.unwrap(),
+          contains('Test error'));
+      expect(eventAttrs['exception.stacktrace']?.value.unwrap(), isNotNull);
+      expect(eventAttrs['exception.escaped']?.value.unwrap(), isTrue);
+      expect(eventAttrs['custom']?.value.unwrap(), equals('attribute'));
     });
 
     test('createSpan throws ArgumentError for invalid span context', () {

--- a/test/unit/api/trace/span_exception_test.dart
+++ b/test/unit/api/trace/span_exception_test.dart
@@ -43,9 +43,9 @@ void main() {
       expect(events?.first.name, equals('exception'));
 
       final attrs = events?.first.attributes?.toMap() ?? {};
-      expect(attrs['exception.type']?.value, contains('Exception'));
-      expect(
-          attrs['exception.message']?.value, equals('Exception: Test error'));
+      expect(attrs['exception.type']?.value.unwrap(), contains('Exception'));
+      expect(attrs['exception.message']?.value.unwrap(),
+          equals('Exception: Test error'));
     });
 
     test('records exception with stack trace', () {
@@ -59,8 +59,8 @@ void main() {
       expect(events, hasLength(1));
 
       final attrs = events?.first.attributes?.toMap() ?? {};
-      expect(attrs['exception.stacktrace']?.value, isNotNull);
-      expect(attrs['exception.stacktrace']?.value.toString(),
+      expect(attrs['exception.stacktrace']?.value.unwrap(), isNotNull);
+      expect(attrs['exception.stacktrace']?.value.unwrap().toString(),
           contains('test/unit/api/trace/span_exception_test.dart'));
     });
 
@@ -70,7 +70,7 @@ void main() {
 
       final events = span.spanEvents;
       final attrs = events?.first.attributes?.toMap() ?? {};
-      expect(attrs['exception.escaped']?.value, true);
+      expect(attrs['exception.escaped']?.value.unwrap(), true);
     });
 
     test('records exception with additional attributes', () {
@@ -83,10 +83,10 @@ void main() {
 
       final events = span.spanEvents;
       final attrs = events?.first.attributes?.toMap() ?? {};
-      expect(attrs['custom.attribute']?.value, equals('value'));
-      expect(attrs['exception.type']?.value, contains('Exception'));
-      expect(
-          attrs['exception.message']?.value, equals('Exception: Test error'));
+      expect(attrs['custom.attribute']?.value.unwrap(), equals('value'));
+      expect(attrs['exception.type']?.value.unwrap(), contains('Exception'));
+      expect(attrs['exception.message']?.value.unwrap(),
+          equals('Exception: Test error'));
     });
 
     test('additional attributes override default exception attributes', () {
@@ -100,8 +100,9 @@ void main() {
 
       final events = span.spanEvents;
       final attrs = events?.first.attributes?.toMap() ?? {};
-      expect(attrs['exception.type']?.value, equals('CustomType'));
-      expect(attrs['exception.message']?.value, equals('Custom message'));
+      expect(attrs['exception.type']?.value.unwrap(), equals('CustomType'));
+      expect(
+          attrs['exception.message']?.value.unwrap(), equals('Custom message'));
     });
 
     test('handles exceptions after span is ended', () {
@@ -119,9 +120,11 @@ void main() {
 
       final events = span.spanEvents;
       expect(events, hasLength(2));
-      expect(events?[0].attributes?.toMap()['exception.message']?.value,
+      expect(
+          events?[0].attributes?.toMap()['exception.message']?.value.unwrap(),
           equals('Exception: Error 1'));
-      expect(events?[1].attributes?.toMap()['exception.message']?.value,
+      expect(
+          events?[1].attributes?.toMap()['exception.message']?.value.unwrap(),
           equals('Exception: Error 2'));
     });
 

--- a/test/unit/api/trace/span_test.dart
+++ b/test/unit/api/trace/span_test.dart
@@ -79,10 +79,10 @@ void main() {
       span.attributes = attrs;
 
       final spanAttrs = span.attributes.toMap();
-      expect(spanAttrs['string.key']?.value, equals('value'));
-      expect(spanAttrs['int.key']?.value, equals(42));
-      expect(spanAttrs['bool.key']?.value, equals(true));
-      expect(spanAttrs['double.key']?.value, equals(3.14));
+      expect(spanAttrs['string.key']?.value.value, equals('value'));
+      expect(spanAttrs['int.key']?.value.value, equals(42));
+      expect(spanAttrs['bool.key']?.value.value, equals(true));
+      expect(spanAttrs['double.key']?.value.value, equals(3.14));
     });
 
     test('handles attribute type-specific setters', () {
@@ -215,7 +215,8 @@ void main() {
       final event = events?.first;
       expect(event?.name, equals('test-event'));
 
-      expect(event?.attributes?.toMap()['event.key']?.value, equals('value'));
+      expect(event?.attributes?.toMap()['event.key']?.value.value,
+          equals('value'));
       expect(event?.timestamp, IsBetween(beforeCreation, afterCreation));
     });
 
@@ -277,8 +278,8 @@ void main() {
       final typeKey = 'exception.type';
       final msgKey = 'exception.message';
 
-      expect(eventAttrs[typeKey]?.value, contains('Exception'));
-      expect(eventAttrs[msgKey]?.value, equals(exception.toString()));
+      expect(eventAttrs[typeKey]?.value.unwrap(), contains('Exception'));
+      expect(eventAttrs[msgKey]?.value.unwrap(), equals(exception.toString()));
     });
 
     test('recordException with custom attributes', () {
@@ -294,8 +295,9 @@ void main() {
       final eventAttrs = events?.first.attributes?.toMap() ?? {};
 
       // Should contain both standard exception attributes and custom ones
-      expect(eventAttrs['exception.type']?.value, contains('Exception'));
-      expect(eventAttrs['custom']?.value, equals('attribute'));
+      expect(
+          eventAttrs['exception.type']?.value.unwrap(), contains('Exception'));
+      expect(eventAttrs['custom']?.value.unwrap(), equals('attribute'));
     });
 
     test('recordException with escaped string', () {
@@ -309,8 +311,8 @@ void main() {
       final eventAttrs = events?.first.attributes?.toMap() ?? {};
 
       // Should contain the full message with escaping preserved
-      expect(
-          eventAttrs['exception.message']?.value, equals(exception.toString()));
+      expect(eventAttrs['exception.message']?.value.unwrap(),
+          equals(exception.toString()));
     });
 
     test('setAttributes with mixed types', () {

--- a/test/unit/api/trace/tracer_provider_test.dart
+++ b/test/unit/api/trace/tracer_provider_test.dart
@@ -55,9 +55,9 @@ void main() {
       );
 
       expect(tracer, isNotNull);
-      expect(tracer.attributes?.toMap()['library.name']?.value,
+      expect(tracer.attributes?.toMap()['library.name']?.value.unwrap(),
           equals('test-lib'));
-      expect(tracer.attributes?.toMap()['library.version']?.value,
+      expect(tracer.attributes?.toMap()['library.version']?.value.unwrap(),
           equals('1.0.0'));
     });
 


### PR DESCRIPTION
Closes #95

## Description

This PR brings `AnyValue` and the attribute representation into line with the OpenTelemetry specification. Previously the API had no support for maps, nested arrays, bytes or null, and had gaps in how attributes were represented and unwrapped internally.

### Core Changes

1. **`AnyValue` hierarchy**: a sealed hierarchy (`AnyValueString`, `AnyValueBool`, `AnyValueInt`, `AnyValueDouble`, `AnyValueArray`, `AnyValueMap`, `AnyValueBytes`, `AnyValueNull`) covering every attribute and log body type in the specification.
2. **`Attribute` refactor**: the generic `Attribute<T>` becomes a concrete `Attribute` carrying an `AnyValue` payload.
3. **`Attributes` unboxing**: `_getTyped<T>` unboxes `AnyValue` subtypes, promoting ints to doubles when a double is asked for.
4. **Attribute values accept the whole model**: common.md's Attribute section says the value MUST be one of the types defined in `AnyValue`, so a map, a nested array, a byte array and null are all valid attribute values, not just log bodies. That is the gap #95 was filed about.

### Breaking changes

- **`Attribute<T>` is no longer generic.** Every explicit type argument has to go: `Attribute<String> a = ...` becomes `Attribute a = ...`, and `List<Attribute<Object>>` becomes `List<Attribute>`. `attribute.value` is now an `AnyValue` rather than the raw Dart value, so read it through the typed `Attributes` getters or unwrap it. Construction is unaffected, since the `Attribute` constructor was already private.
- **`LogRecord.body` is an `AnyValue?`** rather than an `Object?`, so a reader gets the typed model. `APILogger.emit(body: ...)` still takes a plain `Object?`, so callers are unaffected, and it accepts an `AnyValue` too, so `emit(body: record.body)` forwards a record without re-wrapping it. An SDK boxes the body with the new `APILogger.bodyToAnyValue` static, which reports a body it cannot convert through `OTelErrorHandling` and drops it rather than throwing into the caller's logging path.
- **A `Uint8List` attribute value is stored as a byte array** rather than flattened into an integer list. It used to match the old `value is List<int>` branch, so `getIntList` returned the bytes as ints. It is now an `AnyValueBytes`, read back through `attributes.toMap()[key]!.value`. `Int32List` and other typed lists are unaffected and still convert as arrays.
- **The map entry points take `Map<String, Object?>`.** `Attributes.of`, `OTelAPI.attributesFromMap`, `OTelFactory.attributesFromMap` and the `toAttributes()` extension widened their parameter so a null attribute value can be passed. An `OTelFactory` implementation overriding `attributesFromMap` must widen to match.
- **`AnyValueArray`, `AnyValueMap` and `AnyValueBytes` are no longer `const` constructible.** They copy their contents into unmodifiable collections, which a `const` constructor cannot do. The five scalar subtypes remain `const`.
- **An empty attribute key is dropped and reported** rather than stored. The factories do not throw: error-handling.md makes throwing at end-user misuse a MUST NOT, so the drop happens in `Attributes._` and is reported.

### Correctness fixes found

- `Uint8List` now converts to `AnyValueBytes`. It implements `List<int>`, so the list branch caught it first and `AnyValueBytes` was unreachable from `fromObject`. Other typed lists such as `Int32List` still convert as arrays.
- `AnyValueBytes` rejects elements outside 0-255 rather than masking them into range the way a bare `Uint8List` would. Silently truncating a byte corrupts an opaque payload. A `Uint8List` input skips the scan, being in range by construction.
- Conversion is depth limited to 32 levels in both directions. A deeper structure throws an `ArgumentError` that `attrsFromMap` catches, dropping and reporting that attribute.
- The collection subtypes copy defensively into unmodifiable collections. They are value-equal and used as keys, so sharing the caller's list would let a later mutation change a stored value's `hashCode`. Their deep hashes are cached, since the values are immutable.
- `Attribute.toString` renders through `AnyValue.toString` rather than the raw payload, which previously printed an array as `AttributeValue([Instance of 'AnyValueString', ...])`. The rendering is bounded in both directions, because `toString` runs where an exception or a megabyte of output is least welcome: nesting past the depth limit truncates rather than throwing, and bytes render as `<N bytes>` rather than their contents. A String nested in a collection is quoted, so `["a", "b"]` and `["a, b"]` are distinguishable.
- `getDouble` promotes a stored int, and `getDoubleList` promotes an all-int array. Promotion is one way: `getInt` on a stored double still returns null. This also absorbs the web's single number type, where `2.0 is int` is true and a whole-valued double is stored as an `AnyValueInt`.

### Conversion of arbitrary values

`AnyValue.fromObject` follows "Mapping Arbitrary Data to OTLP AnyValue". A type with no dedicated mapping is converted through its `toString()`, per that document's Other Values rules. If `toString()` itself throws, the failure is reported through `OTelErrorHandling` and the value becomes an empty `AnyValue`, which is the last resort the same section prescribes. The intermediate `bytes_value` step is skipped, since Dart offers no general way to serialise an arbitrary object to bytes.

Two conditions are still refused outright, and both throw an `ArgumentError` that `attrsFromMap` and `fromJson` catch, drop and report: a non-String map key, and a structure nested more than 32 levels deep. The mapping doc says non-String keys MUST be stringified too; that is a separate rule with its own test surface and I am happy to do it here or as a follow-up.

Worth knowing: a class with no custom `toString()` stringifies to `Instance of 'MyClass'`, which is rarely the telemetry anyone wanted. That is the spec-prescribed outcome, so it is documented on `fromObject` rather than detected.

### Not changed, deliberately

`AnyValue.toJson` is `unwrap`, so plain Dart objects, bytes included. It is **not** the OTLP/JSON wire encoding, which is tagged (`{"intValue": "1"}`, with int64 as a String) and is produced SDK-side from the protobuf model. An earlier revision of this PR base64-encoded bytes in `toJson` and claimed OTLP/JSON; a reviewer correctly pointed out that this was a near-duplicate of `unwrap` with a surprising difference and a false claim in the docs, so it was reverted rather than extended. If you want a real tagged encoder in the API, that is a separate PR and I am happy to open it.

The typed `Attributes` getters still return only the primitive and homogeneous-list shapes. `getString` on a map attribute returns null and reports a type mismatch, the same as asking for the wrong primitive type. Reach the rest through `attributes.toMap()[key]!.value`, which hands back the `AnyValue`. A `getAnyValue(key)` convenience would be easy to add if it is wanted.

## Downstream impact on the SDK

**The SDK does not compile against this branch.** Verified by pointing `dartastic_opentelemetry` at this branch through `dependency_overrides`: 15 analyzer errors and 184 test files failing to load. Eight of the errors are `wrong_number_of_type_arguments` on `Attribute<String>` and friends in `lib/src/otel.dart`, one in `exemplar.dart`, one `invalid_override` on `SDKLogRecord.body`, and five in `otel_sdk_test.dart`.

**The analyzer does not catch the more serious problem.** `log_record_transformer.dart` and `metric_transformer.dart` test attribute values with `is String` / `is List<String>` chains that now all evaluate false and fall through to an `else` branch doing `anyValue.stringValue = attr.value.toString()`. No compile error, no crash: every attribute would export as the stringification of an `AnyValue` wrapper object rather than the value inside it.

**No published SDK breaks.** The SDK pins `dartastic_opentelemetry_api: '>=1.0.0-rc.3 <1.0.0-rc.4'`, which excludes rc.4, so publishing does not break an existing user. The breakage lands when that constraint widens.

**Proposed sequencing:** I open a companion SDK PR rewriting both transformers to switch on the sealed hierarchy rather than patching the `is` chains, which makes the accidental stringification unreachable by construction and adds the `AnyValueMap`, `AnyValueArray` and `AnyValueBytes` cases setting the matching protobuf fields. Happy to land that first, land them together, or land this one first, whichever you prefer.

## Design notes

**Non-generic `Attribute`.** I weighed keeping `Attribute<T>` where `T extends AnyValue` against dropping the generic. Dropping it won: keeping `T` on the `Attributes` getters meant deep casting complexity, and an attribute is a heterogeneous key/value pair in the specification anyway.

**Where validation lives.** `Attributes._` is the single constructor every `Attributes` passes through: `attrsFromMap`, `fromJson`, `attributesFromList`, an `Attribute` passed straight through `attrsFromMap`, and the `copyWith*` methods. The non-empty-key rule is enforced there for that reason. An earlier revision of this PR also enforced a narrower *value* rule there, restricting attribute values to primitives and homogeneous arrays. A reviewer pointed out that this reimplemented the exact bug #95 was filed about, and they were right: common.md defines an attribute value as any `AnyValue` type. The value restriction is gone and only the key rule remains.

**A null inside an array is preserved.** common/README.md makes this a MUST where it cannot be prevented at compile time, and `['a', null, 'c']` now round-trips. The typed getters cannot express it, since `_getTyped` hands back `List<String>` rather than `List<String?>`, so read such an array through `toMap()[key]!.value` instead.

**The no-op `emit` does nothing at all.** An earlier revision converted the body so an unrepresentable one would be reported even with no SDK installed. A reviewer pointed out that logs/noop.md says the No-Op Logger accepts the parameters without validating them, and that the cost landed on exactly the users who installed no SDK. They were right, and there is a stronger argument still: with no SDK no record is produced, so there is nothing an unrepresentable body could corrupt, and reporting on the body alone while silently discarding every other field of the same record was arbitrary. `emit` is now empty, and a test using a read-counting `List` asserts it never touches the body.

**`emit(body:)` signature.** An earlier revision had `emit` take `AnyValue?`, which meant a caller passing a domain object got an `ArgumentError` thrown into their logging path. A reviewer flagged the ergonomic cost and I agree the error routing argument is stronger still: telemetry that fails should not take down the caller. `emit` now takes `Object?`, and an SDK boxes it through `APILogger.bodyToAnyValue`, reporting and dropping a body it cannot convert. `LogRecord.body` stays `AnyValue?` so the model reader gets the strong type. `bodyToAnyValue` passes an existing `AnyValue` straight through, so `emit(body: record.body)` forwards a record rather than re-wrapping it.

`bodyToAnyValue` is deliberately `static` rather than an instance method. `OTelLogger` in the SDK implements `APILogger` rather than extending it, and `implements` requires a concrete implementation of every public instance member. `@protected` is an annotation, not a visibility modifier, so a `@protected` instance method would have forced the SDK to write its own copy of the report-and-drop logic. As a static it stays out of the interface and the SDK calls `APILogger.bodyToAnyValue(body)` to get the identical behavior. Verified against the SDK's exact class shape.

## Authorship

- Assisted-by: Claude
