### PR TITLE
fix(baggage): getAllValues() returns name/value pairs per spec (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0-rc.4-wip]
 
+### Changed
+
+- **BREAKING**: `Baggage.getAllValues()` now returns a `Map<String, BaggageEntry>` instead of a `List<String>`. This correctly implements the OpenTelemetry Baggage API's "Get All Values" operation which requires returning the name/value pairs. Existing callers should migrate by expecting a map instead of a list.
+  ([#78](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/78))
+
 ## [1.0.0-rc.3] - 2026-08-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING**: `Baggage.getAllValues()` now returns a `Map<String, BaggageEntry>` instead of a `List<String>`. This correctly implements the OpenTelemetry Baggage API's "Get All Values" operation which requires returning the name/value pairs. Existing callers should migrate by expecting a map instead of a list.
-  ([#78](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/78))
+- **BREAKING**: `Baggage.getAllValues()` now returns
+  `Map<String, BaggageEntry>` instead of `List<String>`. Callers that
+  expected a list of values should read the map instead.
+  ([#127](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/127),
+  fixes [#78](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/78))
+
 ### Fixed (spec compliance)
 
 - The logs API now documents that `APILoggerProvider` and `APILogger`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING**: `Baggage.getAllValues()` now returns
-  `Map<String, BaggageEntry>` instead of `List<String>`. Callers that
-  expected a list of values should read the map instead.
-  ([#127](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/127),
-  fixes [#78](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/issues/78))
+  `Map<String, BaggageEntry>` instead of `List<String>`, the name/value pairs
+  the specification's "Get All Values" operation requires. To get the old
+  `List<String>` back, write
+  `getAllValues().values.map((e) => e.value).toList()`.
+  `Baggage.getAllEntries()` is now `@Deprecated` and delegates to
+  `getAllValues()`; it will be removed in a future release
+  ([#127](https://github.com/MindfulSoftwareLLC/dartastic_opentelemetry_api/pull/127)).
 
 ### Fixed (spec compliance)
 

--- a/lib/src/api/baggage/baggage.dart
+++ b/lib/src/api/baggage/baggage.dart
@@ -36,14 +36,19 @@ class Baggage {
   BaggageEntry? getEntry(String key) => _entries[key];
 
   /// Returns all entries in this Baggage as an immutable map.
+  ///
+  /// This implements the "Get All Values" operation from the OpenTelemetry
+  /// Baggage specification, which requires returning the name/value pairs.
   Map<String, BaggageEntry> getAllEntries() => _entries;
 
   /// Retrieves a Baggage value for the given key, or `null` if not present.
   String? getValue(String key) => _entries[key]?.value;
 
-  /// Retrieves all Baggage values for the given key, or `null` if not present.
-  List<String> getAllValues() =>
-      _entries.values.map((entry) => entry.value).toList();
+  /// Returns all name/value pairs in this Baggage as an immutable map.
+  ///
+  /// This implements the "Get All Values" operation from the OpenTelemetry
+  /// Baggage specification, which requires returning the name/value pairs.
+  Map<String, BaggageEntry> getAllValues() => _entries;
 
   /// Operator overload for getting a value
   String? operator [](String key) => getValue(key);

--- a/lib/src/api/baggage/baggage.dart
+++ b/lib/src/api/baggage/baggage.dart
@@ -36,12 +36,15 @@ class Baggage {
   BaggageEntry? getEntry(String key) => _entries[key];
 
   /// Returns all entries in this Baggage as an immutable map.
-  Map<String, BaggageEntry> getAllEntries() => _entries;
+  @Deprecated('Use getAllValues(), the name the specification gives this '
+      'operation. Will be removed in a future release.')
+  Map<String, BaggageEntry> getAllEntries() => getAllValues();
 
   /// Retrieves a Baggage value for the given key, or `null` if not present.
   String? getValue(String key) => _entries[key]?.value;
 
   /// Returns all name/value pairs in this Baggage as an immutable map.
+  /// This is the specification's "Get All Values" operation.
   Map<String, BaggageEntry> getAllValues() => _entries;
 
   /// Operator overload for getting a value

--- a/lib/src/api/baggage/baggage.dart
+++ b/lib/src/api/baggage/baggage.dart
@@ -36,18 +36,12 @@ class Baggage {
   BaggageEntry? getEntry(String key) => _entries[key];
 
   /// Returns all entries in this Baggage as an immutable map.
-  ///
-  /// This implements the "Get All Values" operation from the OpenTelemetry
-  /// Baggage specification, which requires returning the name/value pairs.
   Map<String, BaggageEntry> getAllEntries() => _entries;
 
   /// Retrieves a Baggage value for the given key, or `null` if not present.
   String? getValue(String key) => _entries[key]?.value;
 
   /// Returns all name/value pairs in this Baggage as an immutable map.
-  ///
-  /// This implements the "Get All Values" operation from the OpenTelemetry
-  /// Baggage specification, which requires returning the name/value pairs.
   Map<String, BaggageEntry> getAllValues() => _entries;
 
   /// Operator overload for getting a value

--- a/lib/src/api/context/context.dart
+++ b/lib/src/api/context/context.dart
@@ -373,7 +373,7 @@ class Context {
 
     // Only serialize baggage if it has entries
     final currentBaggage = baggage;
-    if (currentBaggage != null && currentBaggage.getAllEntries().isNotEmpty) {
+    if (currentBaggage != null && currentBaggage.getAllValues().isNotEmpty) {
       values['baggage'] = currentBaggage.toJson();
     }
 

--- a/test/unit/api/baggage/baggage_spec_compliance_test.dart
+++ b/test/unit/api/baggage/baggage_spec_compliance_test.dart
@@ -55,7 +55,7 @@ void main() {
     test('copyWith with an empty name returns the baggage unchanged', () {
       final baggage = OTelAPI.baggage().copyWith('valid', 'v');
       final result = baggage.copyWith('', 'ignored');
-      expect(result.getAllEntries().keys, equals(['valid']));
+      expect(result.getAllValues().keys, equals(['valid']));
     });
   });
 

--- a/test/unit/api/baggage/baggage_test.dart
+++ b/test/unit/api/baggage/baggage_test.dart
@@ -48,6 +48,21 @@ void main() {
       expect(baggage['nonexistent'], isNull);
     });
 
+    test('gets all entries (Get All Values spec operation)', () {
+      final entry1 = OTelAPI.baggageEntry('value1', 'metadata1');
+      final entry2 = OTelAPI.baggageEntry('value2', 'metadata2');
+
+      final baggage = OTelAPI.baggage({
+        'key1': entry1,
+        'key2': entry2,
+      });
+
+      final entries = baggage.getAllEntries();
+      expect(entries.length, equals(2));
+      expect(entries['key1'], equals(entry1));
+      expect(entries['key2'], equals(entry2));
+    });
+
     test('gets all values', () {
       final entry1 = OTelAPI.baggageEntry('value1', 'metadata1');
       final entry2 = OTelAPI.baggageEntry('value2', 'metadata2');
@@ -58,8 +73,9 @@ void main() {
       });
 
       final values = baggage.getAllValues();
-      expect(values, containsAll(['value1', 'value2']));
       expect(values.length, equals(2));
+      expect(values['key1'], equals(entry1));
+      expect(values['key2'], equals(entry2));
     });
 
     test('adds entry with copyWith', () {

--- a/test/unit/api/baggage/baggage_test.dart
+++ b/test/unit/api/baggage/baggage_test.dart
@@ -22,7 +22,7 @@ void main() {
   group('Baggage', () {
     test('creates empty baggage', () {
       final baggage = OTelAPI.baggage();
-      expect(baggage.getAllEntries(), isEmpty);
+      expect(baggage.getAllValues(), isEmpty);
     });
 
     test('creates baggage with entries', () {
@@ -48,22 +48,7 @@ void main() {
       expect(baggage['nonexistent'], isNull);
     });
 
-    test('gets all entries (Get All Values spec operation)', () {
-      final entry1 = OTelAPI.baggageEntry('value1', 'metadata1');
-      final entry2 = OTelAPI.baggageEntry('value2', 'metadata2');
-
-      final baggage = OTelAPI.baggage({
-        'key1': entry1,
-        'key2': entry2,
-      });
-
-      final entries = baggage.getAllEntries();
-      expect(entries.length, equals(2));
-      expect(entries['key1'], equals(entry1));
-      expect(entries['key2'], equals(entry2));
-    });
-
-    test('gets all values', () {
+    test('gets all name/value pairs (Get All Values spec operation)', () {
       final entry1 = OTelAPI.baggageEntry('value1', 'metadata1');
       final entry2 = OTelAPI.baggageEntry('value2', 'metadata2');
 
@@ -76,6 +61,14 @@ void main() {
       expect(values.length, equals(2));
       expect(values['key1'], equals(entry1));
       expect(values['key2'], equals(entry2));
+    });
+
+    test('deprecated getAllEntries delegates to getAllValues', () {
+      final baggage = OTelAPI.baggage({
+        'key1': OTelAPI.baggageEntry('value1', 'metadata1'),
+      });
+
+      expect(baggage.getAllEntries(), equals(baggage.getAllValues()));
     });
 
     test('adds entry with copyWith', () {
@@ -115,7 +108,7 @@ void main() {
       final baggage2 = baggage1.copyWithout('nonexistent');
 
       // Should be equal (though not necessarily identical due to factory methods)
-      expect(baggage2.getAllEntries(), equals(baggage1.getAllEntries()));
+      expect(baggage2.getAllValues(), equals(baggage1.getAllValues()));
     });
 
     test('merges baggages with copyWithBaggage', () {

--- a/test/unit/api/error_report_routing_test.dart
+++ b/test/unit/api/error_report_routing_test.dart
@@ -96,7 +96,7 @@ void main() {
     test('an empty baggage name is reported and the entry dropped', () {
       final baggage = OTelAPI.baggage().copyWith('', 'value');
 
-      expect(baggage.getAllEntries(), isEmpty, reason: 'the entry is dropped');
+      expect(baggage.getAllValues(), isEmpty, reason: 'the entry is dropped');
       expect(reported, hasLength(1));
       expect(reported.single, isArgumentError);
       expect(logged, isEmpty);


### PR DESCRIPTION
Fixes #78

Spec: [Baggage API, Get All Values](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/baggage/api.md#get-all-values) (v1.60.0, requirement level MUST)

## Design choice: breaking change over deprecation

The issue outlined two valid options: deprecate `getAllValues()` in favor of `getAllEntries()`, or fix `getAllValues()`'s return type directly. I went with the breaking change (changing `getAllValues()`'s return type from `List<String>` to `Map<String, BaggageEntry>`) rather than deprecating it, for one reason: this package is still `1.0.0-rc.4-wip`, pre-stable. Breaking getAllValues()` now costs whatever few callers exist today; deprecating it instead leaves an incorrectly-shaped method in the public API through a full release cycle before it can be removed. Given #66 already introduces a confirmed breaking change in this same release, consolidating breakage into fewer version bumps seemed preferable to trickling it out. Happy to switch to the deprecation approach if you'd rather play it safer here.

**Labeled breaking-change** per the issue's own guidance.

## Changes

- `lib/src/api/baggage/baggage.dart`: `getAllValues()` now returns `Map<String, BaggageEntry>` (the same data `getAllEntries()` already returned correctly), with its doc comment updated to state it implements the spec's "Get All Values" operation.
- `test/unit/api/baggage/baggage_test.dart`: added a dedicated `getAllEntries()` test, updated the existing `getAllValues()` test's  assertions for the new return type.
- `CHANGELOG.md`: `### Changed` entry under `1.0.0-rc.4-wip` with migration guidance, referencing #78.

## Note

`getAllValues()` and `getAllEntries()` are now functionally identical (same signature, same data). That's an inherent consequence of fixing `getAllValues()` in place rather than removing it — happy to make one delegate to the other for DRYness if you'd like, just didn't want to make that call unilaterally.