### PR TITLE
Apply W3C tracestate truncation in toHeaderString

### DIFF
--- a/lib/src/api/trace/trace_state.dart
+++ b/lib/src/api/trace/trace_state.dart
@@ -9,6 +9,15 @@ part 'trace_state_create.dart';
 
 /// Key-value pairs carried along with a span context.
 /// TraceState follows the W3C Trace Context specification.
+///
+/// Size policy: the grammar limits (W3C §3.3.1.1) — a maximum of 32
+/// list-members and the per-key/per-value length rules — are enforced on
+/// every path. [toString] serializes exactly what the state holds and
+/// does not truncate beyond them; [toHeaderString] applies the §3.3.1.5
+/// truncation procedure for callers that need a bounded header value.
+/// Vendors SHOULD propagate at least 512 characters of the combined
+/// header, so 512 is a floor the procedure keeps whole entries within,
+/// not a ceiling imposed on the state itself.
 class TraceState {
   static const int _maxKeyValuePairs = 32;
   static final RegExp _simpleKeyFormat = RegExp(r'^[a-z][a-z0-9_\-*/]{0,255}$');

--- a/lib/src/api/trace/trace_state.dart
+++ b/lib/src/api/trace/trace_state.dart
@@ -119,6 +119,41 @@ class TraceState {
     return _entries.entries.map((e) => '${e.key}=${e.value}').join(',');
   }
 
+  /// Produces the W3C `tracestate` header value, applying the truncation
+  /// procedure of W3C Trace Context §3.3.1.5.
+  ///
+  /// Entries over 128 characters are removed first, then entries are removed
+  /// from the end until the joined value fits the 512-character budget.
+  /// Only whole entries are removed, and every dropped entry is reported
+  /// through [OTelErrorHandling]. Unlike [toString], this may return a value
+  /// that no longer contains all entries.
+  String toHeaderString() {
+    final entries = List<MapEntry<String, String>>.from(_entries.entries);
+
+    // W3C §3.3.1.5: entries larger than 128 characters should be removed
+    // first. The length of a list-member is its `key=value` size.
+    final overlong = entries
+        .where((e) => '${e.key}=${e.value}'.length > 128)
+        .toList(growable: false);
+    for (final entry in overlong) {
+      entries.remove(entry);
+      OTelErrorHandling.report(StateError(
+          'TraceState entry ${entry.key} exceeds 128 characters; dropped.'));
+    }
+
+    // Then entries should be removed starting from the end of the
+    // tracestate until the value fits the 512-character budget.
+    var value = entries.map((e) => '${e.key}=${e.value}').join(',');
+    while (value.length > 512 && entries.isNotEmpty) {
+      final entry = entries.removeLast();
+      OTelErrorHandling.report(StateError(
+          'TraceState exceeds 512 characters; entry ${entry.key} dropped.'));
+      value = entries.map((e) => '${e.key}=${e.value}').join(',');
+    }
+
+    return value;
+  }
+
   /// Validate a tracestate key: a simple key, or a multi-tenant
   /// `tenant-id@system-id` key.
   static bool _isValidKey(String key) {

--- a/lib/src/api/trace/trace_state.dart
+++ b/lib/src/api/trace/trace_state.dart
@@ -131,16 +131,23 @@ class TraceState {
   /// Produces the W3C `tracestate` header value, applying the truncation
   /// procedure of W3C Trace Context §3.3.1.5.
   ///
-  /// Entries over 128 characters are removed first, then entries are removed
-  /// from the end until the joined value fits the 512-character budget.
-  /// Only whole entries are removed, and every dropped entry is reported
-  /// through [OTelErrorHandling]. Unlike [toString], this may return a value
-  /// that no longer contains all entries.
+  /// The procedure only runs when the value needs to be truncated: if the
+  /// joined value fits the 512-character budget it is returned as-is,
+  /// including entries over 128 characters. When it does not fit, whole
+  /// entries are removed, entries larger than 128 characters first, then
+  /// entries from the end until the value fits. Every dropped entry is
+  /// reported through [OTelErrorHandling]. Unlike [toString], this may
+  /// return a value that no longer contains all entries.
   String toHeaderString() {
-    final entries = List<MapEntry<String, String>>.from(_entries.entries);
+    var value = _entries.entries.map((e) => '${e.key}=${e.value}').join(',');
+    if (value.length <= 512) {
+      return value;
+    }
 
-    // W3C §3.3.1.5: entries larger than 128 characters should be removed
-    // first. The length of a list-member is its `key=value` size.
+    // W3C §3.3.1.5: "Entries larger than 128 characters long SHOULD be
+    // removed first", as part of truncating a value that does not fit.
+    // The length of a list-member is its `key=value` size.
+    final entries = List<MapEntry<String, String>>.from(_entries.entries);
     final overlong = entries
         .where((e) => '${e.key}=${e.value}'.length > 128)
         .toList(growable: false);
@@ -148,11 +155,11 @@ class TraceState {
       entries.remove(entry);
       OTelErrorHandling.report(StateError(
           'TraceState entry ${entry.key} exceeds 128 characters; dropped.'));
+      value = entries.map((e) => '${e.key}=${e.value}').join(',');
     }
 
     // Then entries should be removed starting from the end of the
     // tracestate until the value fits the 512-character budget.
-    var value = entries.map((e) => '${e.key}=${e.value}').join(',');
     while (value.length > 512 && entries.isNotEmpty) {
       final entry = entries.removeLast();
       OTelErrorHandling.report(StateError(

--- a/test/unit/api/trace/trace_state_spec_compliance_test.dart
+++ b/test/unit/api/trace/trace_state_spec_compliance_test.dart
@@ -62,4 +62,86 @@ void main() {
       expect(result.get('vendor'), isNull);
     });
   });
+
+  group('TraceState toHeaderString follows W3C 3.3.1.5 truncation', () {
+    test('returns the full value when it fits the budget', () {
+      final traceState = TraceState.fromMap({'a': '1', 'b': '2'});
+      expect(traceState.toHeaderString(), equals('a=1,b=2'));
+    });
+
+    test('returns empty string for an empty state', () {
+      final traceState = TraceState.empty();
+      expect(traceState.toHeaderString(), equals(''));
+    });
+
+    test('removes entries over 128 characters first', () {
+      final longValue = List.filled(130, 'v').join();
+      final traceState = TraceState.fromMap({
+        'big': longValue,
+        'ok': 'fine',
+      });
+      final header = traceState.toHeaderString();
+      expect(header, equals('ok=fine'));
+      expect(header.contains('big'), isFalse);
+    });
+
+    test('keeps a long-but-under-128 entry when shorter entries go first', () {
+      // second's entry is 120 characters (key 6 + '=' 1 + value 113),
+      // under the 128 limit, while first is tiny. Nothing is dropped here,
+      // the point is the size does not trigger the 128-char removal.
+      final longValue = List.filled(113, 'x').join();
+      final traceState = TraceState.fromMap({
+        'first': 'old',
+        'second': longValue,
+      });
+      final header = traceState.toHeaderString();
+      expect(header, equals('first=old,second=$longValue'));
+    });
+
+    test('removes whole entries from the end to fit 512 characters', () {
+      final entries = <String, String>{};
+      // 10 entries of ~60 characters each: 600+ total, must drop some.
+      final v55 = List.filled(55, 'v').join();
+      for (var i = 0; i < 10; i++) {
+        entries['k$i'] = v55;
+      }
+      final traceState = TraceState.fromMap(entries);
+      final header = traceState.toHeaderString();
+      expect(header.length, lessThanOrEqualTo(512));
+      // Whole entries only: the header still ends on a complete entry.
+      expect(header.endsWith('}'), isFalse); // sanity, no partial values
+      expect(header.contains('k0='), isTrue, reason: 'oldest kept');
+      // Some of the newest entries had to go.
+      expect(header.contains('k9='), isFalse);
+    });
+
+    test('toString keeps all entries when toHeaderString truncates', () {
+      final entries = <String, String>{};
+      final v55 = List.filled(55, 'v').join();
+      for (var i = 0; i < 10; i++) {
+        entries['k$i'] = v55;
+      }
+      final traceState = TraceState.fromMap(entries);
+      final header = traceState.toHeaderString();
+      expect(header.length, lessThanOrEqualTo(512));
+      expect(traceState.toString().length, greaterThan(512));
+    });
+
+    test('reports dropped entries through OTelErrorHandling', () {
+      final received = <Object>[];
+      OTelErrorHandling.handler = (error, stackTrace) {
+        received.add(error);
+      };
+      try {
+        final longValue = List.filled(200, 'v').join();
+        final traceState = TraceState.fromMap({'big': longValue, 'ok': '1'});
+        traceState.toHeaderString();
+        expect(received.length, 1,
+            reason: 'the overlong entry must be reported once');
+        expect(received.single.toString(), contains('big'));
+      } finally {
+        OTelErrorHandling.resetToDefault();
+      }
+    });
+  });
 }

--- a/test/unit/api/trace/trace_state_spec_compliance_test.dart
+++ b/test/unit/api/trace/trace_state_spec_compliance_test.dart
@@ -74,15 +74,49 @@ void main() {
       expect(traceState.toHeaderString(), equals(''));
     });
 
-    test('removes entries over 128 characters first', () {
+    test('keeps an over-128 entry when the total fits 512', () {
+      // Robert's case: 134 characters total, under budget. The 128 rule
+      // only applies once truncation is needed (W3C 3.3.1.5), so the
+      // entry stays.
       final longValue = List.filled(130, 'v').join();
+      final traceState = TraceState.fromMap({'big': longValue});
+      final header = traceState.toHeaderString();
+      expect(header, equals('big=$longValue'));
+    });
+
+    test('removes over-128 entries first once truncation is needed', () {
+      // 32 entries survive the grammar cap: the 134-character entry
+      // plus 31 twelve-character ones total 567 characters, over budget.
+      // The over-128 entry is removed first, and that alone brings the
+      // value to 433 characters, so the rest survive.
+      final bigValue = List.filled(130, 'v').join(); // big=... 134 chars
+      final entries = <String, String>{'big': bigValue};
+      for (var i = 0; i < 31; i++) {
+        entries['a$i'] = 'y' * 10; // a0=..., 13 chars each with separator
+      }
+      final traceState = TraceState.fromMap(entries);
+      expect(traceState.entries.length, 32);
+      final header = traceState.toHeaderString();
+      expect(header.contains('big'), isFalse,
+          reason: 'over-128 entries are removed first');
+      expect(header.length, lessThanOrEqualTo(512));
+    });
+
+    test('removing one large entry can make the rest fit', () {
+      // 404 + 61 + 61 + separators = 528 characters: over budget. The
+      // over-128 entry is removed, and that alone brings the value to
+      // 123 characters, so the two under-128 entries both survive.
+      final bigValue = List.filled(400, 'v').join(); // big=... 404 chars
+      final ok1Value = List.filled(58, 'w').join(); // ok1=... 62 chars
+      final ok2Value = List.filled(58, 'x').join(); // ok2=... 62 chars
       final traceState = TraceState.fromMap({
-        'big': longValue,
-        'ok': 'fine',
+        'ok1': ok1Value,
+        'ok2': ok2Value,
+        'big': bigValue,
       });
       final header = traceState.toHeaderString();
-      expect(header, equals('ok=fine'));
-      expect(header.contains('big'), isFalse);
+      expect(header, equals('ok1=$ok1Value,ok2=$ok2Value'));
+      expect(header.length, lessThanOrEqualTo(512));
     });
 
     test('keeps a long-but-under-128 entry when shorter entries go first', () {
@@ -134,7 +168,11 @@ void main() {
       };
       try {
         final longValue = List.filled(200, 'v').join();
-        final traceState = TraceState.fromMap({'big': longValue, 'ok': '1'});
+        final entries = <String, String>{'big': longValue};
+        for (var i = 0; i < 31; i++) {
+          entries['a$i'] = 'y' * 10;
+        }
+        final traceState = TraceState.fromMap(entries);
         traceState.toHeaderString();
         expect(received.length, 1,
             reason: 'the overlong entry must be reported once');


### PR DESCRIPTION
Implements the truncation procedure from W3C Trace Context 3.3.1.5, following the shape proposed in my comment on the issue.

`TraceState.toHeaderString()` produces the header value the way the spec asks: entries over 128 characters are removed first, then entries are removed from the end until the joined value fits the 512-character budget. Only whole entries are dropped, and each dropped entry is reported through `OTelErrorHandling` the same way invalid entries already are.

`toString()` is unchanged, so it keeps serializing everything the state still holds; the unbounded and truncated forms are now distinct, and a printed state can not silently disagree with `entries`. If maintainers would rather have the budget configurable or `toString()` itself truncate, I'm open to reshaping this.

The existing 32-member cap stays where it is, in `fromString` and `put`: it is the separate 3.3.1.1 grammar limit.

Tests cover the 128-first ordering, the end-removal ordering against the 512 boundary, whole-entry removal, the `toString`/`toHeaderString` split, and the error reports. Full suite passes locally, `dart analyze` clean.

With this in place, dartastic_opentelemetry#295 can proceed with the propagator delegating to this method instead of its private copy.

Fixes #126
